### PR TITLE
EP-12 공용 버튼 컴포넌트 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,22 +1,12 @@
 import type { StorybookConfig } from '@storybook/nextjs';
 
 const config: StorybookConfig = {
-  "stories": [
-    "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
-  ],
-  "addons": [
-    "@storybook/addon-essentials",
-    "@storybook/addon-onboarding",
-    "@chromatic-com/storybook",
-    "@storybook/addon-interactions"
-  ],
-  "framework": {
-    "name": "@storybook/nextjs",
-    "options": {}
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-onboarding', '@chromatic-com/storybook', '@storybook/addon-interactions'],
+  framework: {
+    name: '@storybook/nextjs',
+    options: {},
   },
-  "staticDirs": [
-    "../public"
-  ]
+  staticDirs: ['../public', { from: '../src/fonts', to: 'src/fonts' }],
 };
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,11 +1,12 @@
-import type { Preview } from '@storybook/react'
+import type { Preview } from '@storybook/react';
+import '@/app/globals.css';
 
 const preview: Preview = {
   parameters: {
     controls: {
       matchers: {
-       color: /(background|color)$/i,
-       date: /Date$/i,
+        color: /(background|color)$/i,
+        date: /Date$/i,
       },
     },
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 
 @theme {
   --text-4xl: 40px;
-  --text-4xl-line-height: 52px;
+  --text-4xl--line-height: 52px;
 
   --text-3xl: 32px;
   --text-3xl--line-height: 42px;

--- a/src/components/ui/buttons/index.tsx
+++ b/src/components/ui/buttons/index.tsx
@@ -1,0 +1,35 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/utils/cn';
+
+const ButtonVariants = cva('flex items-center justify-center font-semibold disabled:cursor-not-allowed text-blue-100', {
+  variants: {
+    variant: {
+      default: 'bg-black-500 hover:bg-black-600 active:bg-black-700 disabled:bg-blue-400',
+      outline: 'border border-black-500 hover:border-black-600 active:border-black-700 disabled:border-blue-400 disabled:bg-blue-300',
+    },
+    size: {
+      xs: 'rounded-lg py-2 px-4 text-xs',
+      sm: 'rounded-lg py-2.5 px-4 text-lg ',
+      md: 'rounded-xl py-3 px-8 text-lg',
+      lg: 'rounded-xl py-4 px-10 text-xl',
+      xl: 'rounded-xl py-5 px-24 text-xl',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'md',
+  },
+});
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof ButtonVariants> {
+  children?: ReactNode;
+}
+
+export default function Button({ variant, size, className, children, ...props }: ButtonProps) {
+  return (
+    <button className={cn(ButtonVariants({ variant, size, className }))} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/src/stories/buttons/index.stories.tsx
+++ b/src/stories/buttons/index.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import Button from '@/components/ui/buttons';
+import { cn } from '@/utils/cn';
+import { Pretendard } from '@/fonts';
+
+const meta: Meta<typeof Button> = {
+  title: 'Button',
+  component: Button,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className={cn('flex h-[300px] w-[500px] items-center justify-center rounded-2xl bg-gray-100', Pretendard.className)}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      options: ['default', 'outline'],
+      control: { type: 'select' },
+    },
+    size: {
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      control: { type: 'select' },
+    },
+    disabled: {
+      options: [false, true],
+      control: { type: 'inline-radio' },
+    },
+    children: {
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: {
+    children: '시작하기',
+    disabled: false,
+    onClick: action('default variant 클릭'),
+    className: '',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: 'outline',
+    children: '시작하기',
+    disabled: false,
+    onClick: action('outline variant 클릭'),
+    className: '',
+  },
+};

--- a/src/stories/buttons/index.stories.tsx
+++ b/src/stories/buttons/index.stories.tsx
@@ -58,3 +58,21 @@ export const Outline: Story = {
     className: '',
   },
 };
+
+export const WFull: Story = {
+  args: {
+    children: '시작하기',
+    disabled: false,
+    onClick: action('outline variant 클릭'),
+    className: 'w-full',
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    children: '시작하기',
+    disabled: false,
+    onClick: action('outline variant 클릭'),
+    className: 'bg-red-200',
+  },
+};

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## ❓이슈
- close #6 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

공용 버튼 컴포넌트에 관한 PR입니다.

작업한 내용은 다음과 같습니다.
1. cn함수 구현(shadcn에서 사용하는 함수 가져왔습니다.)
2. storybook 셋업 수정(css 파일 import 및 폰트 정적 경로 추가)
3. 공용 버튼 컴포넌트 구현(cva로 variants 설정하여 구현했습니다.)
4. 버튼 컴포넌트 스토리 작성(variant, w-full, custom class로 작성했습니다.)

cn함수의 경우 직접 구현한게 아니라 다른 라이브러리에서 가져온 코드 조각이라 unit test는 작성하지 않았습니다.

실제 HTML button태그처럼 사용하도록 구현하였으며, 사용 예시는 다음과 같습니다.

```js
<Button>
  테스트
</Button>
```

Decorator를 사용해서 Wrapper 컴포넌트처럼 본래 스토리 컴포넌트를 감싸주었고, font도 적용해놨습니다.

storybook에서 따로 class로 font를 지정하지 않으면 폰트 적용이 안되기에 Wrapper의 class에 추가했습니다.
```js
const meta: Meta<typeof Button> = {
  title: 'Button',
  component: Button,
  tags: ['autodocs'],
  parameters: {
    layout: 'centered',
  },
  decorators: [
    (Story) => (
      <div className={cn('flex h-[300px] w-[500px] items-center justify-center rounded-2xl bg-gray-100', Pretendard.className)}>
        <Story />
      </div>
    ),
  ],
...
};
```

### 스토리북 발췌
![image](https://github.com/user-attachments/assets/51c88e57-0c98-481e-9f84-1ba9632107e0)


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
