### PR TITLE
EP-18 공용 Avatar 컴포넌트 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -6,6 +6,14 @@ const nextConfig: NextConfig = {
     fetches: {
       fullUrl: true,
     },
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+      },
+    ],
   },
 };
 

--- a/src/components/ui/avatars/index.tsx
+++ b/src/components/ui/avatars/index.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/utils/cn';
+import { cva, type VariantProps } from 'class-variance-authority';
+import Image, { ImageProps } from 'next/image';
+
+const avatarVariants = cva('rounded-full flex items-center justify-center', {
+  variants: {
+    size: {
+      default: 'size-12',
+      lg: 'size-[120px] border-2 border-blue-300',
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+});
+
+interface AvatarProps extends Omit<ImageProps, 'src'>, VariantProps<typeof avatarVariants> {
+  src?: string | null;
+}
+
+export default function Avatar({ src = process.env.NEXT_PUBLIC_DEFAULT_IMAGE_URL!, alt, size, className, ...props }: AvatarProps) {
+  const encodedUri = encodeURI(src ?? process.env.NEXT_PUBLIC_DEFAULT_IMAGE_URL!);
+  return <Image src={encodedUri} alt={alt} width={120} height={120} className={cn(avatarVariants({ size, className }))} {...props} />;
+}

--- a/src/components/ui/buttons/index.tsx
+++ b/src/components/ui/buttons/index.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 import { cn } from '@/utils/cn';
 
-const ButtonVariants = cva('flex items-center justify-center font-semibold disabled:cursor-not-allowed text-blue-100', {
+const buttonVariants = cva('flex items-center justify-center font-semibold disabled:cursor-not-allowed text-blue-100', {
   variants: {
     variant: {
       default: 'bg-black-500 hover:bg-black-600 active:bg-black-700 disabled:bg-blue-400',
@@ -22,13 +22,13 @@ const ButtonVariants = cva('flex items-center justify-center font-semibold disab
   },
 });
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof ButtonVariants> {
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   children?: ReactNode;
 }
 
 export default function Button({ variant, size, className, children, ...props }: ButtonProps) {
   return (
-    <button className={cn(ButtonVariants({ variant, size, className }))} {...props}>
+    <button className={cn(buttonVariants({ variant, size, className }))} {...props}>
       {children}
     </button>
   );

--- a/src/stories/avatars/index.stories.tsx
+++ b/src/stories/avatars/index.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Avatar from '@/components/ui/avatars';
+import { cn } from '@/utils/cn';
+import { Pretendard } from '@/fonts';
+
+const TEST_IMAGE_URL =
+  'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Wikied/user/1257/1741667179501/%C3%AD%C2%85%C2%8C%C3%AC%C2%8A%C2%A4%C3%AD%C2%8A%C2%B8%20%C3%AC%C2%9D%C2%B4%C3%AB%C2%AF%C2%B8%C3%AC%C2%A7%C2%80.png';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Avatar/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className={cn('flex h-[300px] w-[500px] items-center justify-center rounded-2xl bg-red-200', Pretendard.className)}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    size: {
+      options: ['default', 'lg'],
+      control: { type: 'select' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Default: Story = {
+  args: {
+    size: 'default',
+    src: TEST_IMAGE_URL,
+    alt: '테스트 이미지',
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    size: 'lg',
+    src: TEST_IMAGE_URL,
+    alt: '테스트 이미지',
+  },
+};
+
+export const NoSrcLargeSize: Story = {
+  args: {
+    size: 'lg',
+    alt: '테스트 이미지',
+  },
+};
+
+export const NullSrcLargeSize: Story = {
+  args: {
+    size: 'lg',
+    src: null,
+    alt: '테스트 이미지',
+  },
+};

--- a/src/stories/buttons/index.stories.tsx
+++ b/src/stories/buttons/index.stories.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/utils/cn';
 import { Pretendard } from '@/fonts';
 
 const meta: Meta<typeof Button> = {
-  title: 'Button',
+  title: 'Button/Button',
   component: Button,
   tags: ['autodocs'],
   parameters: {


### PR DESCRIPTION
## ❓이슈
- close #12 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

공용 아바타 컴포넌트에 관한 PR입니다.

### Note

**DEFAULT IMAGE URL을 환경 변수에 추가하였기 때문에 env파일에 다음과 같이 추가해주시면 됩니다.**

```bash
NEXT_PUBLIC_DEFAULT_IMAGE_URL=https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Wikied/user/1257/1741672359693/round-icons-l47Fr7hQ0Ic-unsplash.jpg
```

추가로, swagger에선 한글명으로 된 이미지 업로드를 하면 정상적으로 렌더링되지 않다고 되어있는데, 이 부분은 인코딩 함수써서 해결하였으므로, 한글 이미지 업로드 request로 받은 URL을 줘도 제대로 동작합니다.

```js
 const encodedUri = encodeURI(src ?? process.env.NEXT_PUBLIC_DEFAULT_IMAGE_URL!);
```

next.config.ts파일에 s3 이미지 도메인도 설정해놨습니다.

```js
import type { NextConfig } from 'next';

const nextConfig: NextConfig = {
  reactStrictMode: true,
  logging: {
    fetches: {
      fullUrl: true,
    },
  },
  images: {
    remotePatterns: [
      {
        protocol: 'https',
        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
      },
    ],
  },
};

export default nextConfig;

```

---
---

variant의 경우 size만 설정하도록 하였고, default는 작은 사이즈의 아바타입니다.
lg 아바타의 경우 figma 시안처럼 border가 생기게 구현했습니다.

필수로 줘야하는 props로는 alt입니다.

api응답에 따라 alt를 설정하는 경우가 많으므로, 필수 prop으로 지정했습니다.
(ex. ~님의 프로필 이미지)

src의 경우 prop으로 주지 않을 경우엔 default image가 렌더링되도록 구현했고, null값을 넘길 경우에도 default image가 렌더링되도록 구현했습니다.

### 스토리북 발췌

![image](https://github.com/user-attachments/assets/1b01af33-82ba-4f16-a603-ec115078a15e)


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
