### PR TITLE
EP-19 공용 Floating Action Button 구현

### DIFF
--- a/src/assets/icons/Upper_Arrow.svg
+++ b/src/assets/icons/Upper_Arrow.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="17" viewBox="0 0 26 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 15L13 3L24 15" stroke="#ECEFF4" stroke-width="3"/>
+</svg>

--- a/src/components/ui/buttons/FloatingButton.tsx
+++ b/src/components/ui/buttons/FloatingButton.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+import Image from 'next/image';
+import { cn } from '@/utils/cn';
+import UpperArrow from '@/assets/icons/Upper_Arrow.svg';
+
+const floatingButtonVariants = cva(
+  cn([
+    'fixed bottom-12 right-12', //
+    'flex items-center justify-center rounded-full bg-blue-900 cursor-pointer', //
+    'hover:bg-black-400',
+  ]),
+  {
+    variants: {
+      size: {
+        md: 'size-8 shadow-[0px_4px_4px_0px_#55555540]',
+        lg: 'size-12 shadow-[0px_4px_4px_0px_#ACACAC33]',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+);
+
+interface FloatingButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof floatingButtonVariants> {
+  children?: ReactNode;
+}
+
+export default function FloatingButton({ size, className, children, ...props }: FloatingButtonProps) {
+  return (
+    <button
+      className={cn(floatingButtonVariants({ size, className }))}
+      {...props}
+      onClick={() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }}
+    >
+      {children ?? (
+        <Image
+          src={UpperArrow}
+          alt='플로팅 액션 버튼 이미지'
+          width={24}
+          height={12}
+          className={cn({
+            'h-2 w-4': size === 'md' || size === undefined,
+            'h-3 w-6': size === 'lg',
+          })}
+        />
+      )}
+    </button>
+  );
+}

--- a/src/stories/buttons/FloatingButton.stories.tsx
+++ b/src/stories/buttons/FloatingButton.stories.tsx
@@ -38,6 +38,13 @@ export const LargeSize: Story = {
   },
 };
 
+export const WithChildrenClassName: Story = {
+  args: {
+    className: 'size-20',
+    children: <span className='text-white'>테스트</span>,
+  },
+};
+
 export const CustomPosition: Story = {
   args: {
     size: 'lg',

--- a/src/stories/buttons/FloatingButton.stories.tsx
+++ b/src/stories/buttons/FloatingButton.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import FloatingButton from '@/components/ui/buttons/FloatingButton';
+import { cn } from '@/utils/cn';
+import { Pretendard } from '@/fonts';
+
+const meta: Meta<typeof FloatingButton> = {
+  title: 'Button/FloatingButton',
+  component: FloatingButton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className={cn('flex h-[300px] w-[500px] items-center justify-center rounded-2xl bg-green-200', Pretendard.className)}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    size: {
+      options: ['md', 'lg'],
+      control: { type: 'select' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FloatingButton>;
+
+export const Default: Story = {
+  args: {},
+};
+export const LargeSize: Story = {
+  args: {
+    size: 'lg',
+    className: '',
+  },
+};
+
+export const CustomPosition: Story = {
+  args: {
+    size: 'lg',
+    className: 'top-8 left-8',
+  },
+};


### PR DESCRIPTION
## ❓이슈
- close #13 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

FAB 버튼 컴포넌트에 관한 PR입니다.

기본적인 포지션은 fixed, bottom: 48px, right: 48px로 위치해놨고, 다른 위치 원하시면 top, left, right, bottom 속성을 적절히 className으로 커스텀하시면 됩니다.

props는 size만 받게하였고, 기본 prop으론 md사이즈입니다.

button안에 children이 있으면 화살표 이미지가 아닌 지정한 children으로 변경됩니다.

스크롤 올라가는 기능은 스토리북으로도 확인 가능합니다.(우선 top:0으로 설정해놨고, 다른 위치로 해야할 땐 수정하겠습니다.)

### 스토리북 발췌 및 시연 영상

https://github.com/user-attachments/assets/63330125-8154-4832-96b2-77921f46047b

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
