### PR TITLE
EP-16 공용 text area 컴포넌트 구현

### DIFF
--- a/src/components/ui/textarea/index.tsx
+++ b/src/components/ui/textarea/index.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+import { cva, VariantProps } from 'class-variance-authority';
+import { TextareaHTMLAttributes, useState, ChangeEvent } from 'react';
+
+const textAreaVariants = cva('bg-white placeholder-blue-300', {
+  variants: {
+    variant: {
+      limit100: '',
+      limit500: '',
+    },
+    size: {
+      '100sm': 'w-[248px] h-[80px] pt-[12px] pb-[42px] px-[16px]',
+      '100md': 'w-[320px] h-[80px] pt-[12px] pb-[42px] px-[16px]',
+      '100lg': 'w-[568px] h-[104px] pt-[12px] pb-[60px] px-[16px]',
+      sm: 'w-[312px] h-[132px] pt-[10px] pb-[96px] px-[16px]',
+      md: 'w-sm h-[132px] pt-[10px] pb-[96px] px-[16px]',
+      lg: 'w-[640px] h-[148px] pt-[10px] pb-[106px] px-[16px]',
+    },
+    fontSize: {
+      base: 'text-base',
+      xl: 'text-xl',
+    },
+    border: {
+      'line-border': 'border border-line-200 border-solid',
+      'blue-border': 'border border-blue-500 border-solid',
+    },
+    borderRadius: {
+      lg: 'rounded-lg',
+      xl: 'rounded-xl',
+    },
+  },
+  defaultVariants: {
+    variant: 'limit100',
+    size: 'md',
+    fontSize: 'base',
+    border: 'line-border',
+    borderRadius: 'lg',
+  },
+});
+
+const charCountContainerStyle = 'absolute -bottom-4 right-0 text-xs flex items-center';
+
+interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>, VariantProps<typeof textAreaVariants> {
+  maxLength?: number;
+}
+
+export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ...props }: TextAreaProps) {
+  const initialValue = value?.toString() || defaultValue?.toString() || '';
+
+  const [charCount, setCharCount] = useState(initialValue.length);
+
+  const charLimit = variant === 'limit100' ? 100 : variant === 'limit500' ? 500 : null;
+  const effectiveMaxLength = maxLength || charLimit || undefined;
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+
+    if (effectiveMaxLength && newValue.length > effectiveMaxLength) {
+      e.target.value = newValue.slice(0, effectiveMaxLength);
+    }
+
+    setCharCount(e.target.value.length);
+
+    // 사용자가 정의한 onChange 핸들러 실행되게.
+    if (onChange) {
+      onChange(e);
+    }
+  };
+
+  return (
+    <div className='relative'>
+      <textarea
+        className={cn(textAreaVariants({ variant, size, fontSize, border, borderRadius }))}
+        onChange={handleChange}
+        maxLength={effectiveMaxLength}
+        value={value}
+        defaultValue={defaultValue}
+        {...props}
+      />
+
+      {charLimit && (
+        <div className={charCountContainerStyle}>
+          <span className={charCount >= charLimit ? 'text-red-500' : 'text-gray-500'}>{charCount}</span>
+          <span className='text-gray-500'>/{charLimit}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/stories/textarea/index.stories.tsx
+++ b/src/stories/textarea/index.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { cn } from '@/utils/cn';
+import TextArea from '@/components/ui/textarea';
+import { Pretendard } from '@/fonts';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'TextArea/TextArea',
+  component: TextArea,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className={cn('rounded-xl bg-white', Pretendard.className)}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      options: ['limit100', 'limit500'],
+      control: { type: 'select' },
+    },
+
+    size: {
+      options: ['sm', 'md', 'lg', '100sm', '100md', '100lg'],
+      control: { type: 'select' },
+    },
+    fontSize: {
+      options: ['base', 'xl'],
+      control: { type: 'select' },
+    },
+    border: {
+      options: ['line-border', 'blue-border'],
+      control: { type: 'select' },
+    },
+    borderRadius: {
+      options: ['lg', 'xl'],
+      control: { type: 'select' },
+    },
+    placeholder: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextArea>;
+
+export const Small100: Story = {
+  args: {
+    variant: 'limit100',
+    size: '100sm',
+    fontSize: 'base',
+    border: 'line-border',
+    borderRadius: 'lg',
+    placeholder: '100자 이내로 입력해주세요.',
+  },
+};
+
+export const Medium100: Story = {
+  args: {
+    variant: 'limit100',
+    size: '100md',
+    fontSize: 'base',
+    border: 'line-border',
+    borderRadius: 'lg',
+    placeholder: '100자 이내로 입력해주세요.',
+  },
+};
+
+export const Large100: Story = {
+  args: {
+    variant: 'limit100',
+    size: '100lg',
+    fontSize: 'xl',
+    border: 'line-border',
+    borderRadius: 'lg',
+    placeholder: '100자 이내로 입력해주세요.',
+  },
+};
+
+export const Small500: Story = {
+  args: {
+    variant: 'limit500',
+    size: 'sm',
+    fontSize: 'base',
+    border: 'blue-border',
+    borderRadius: 'xl',
+    placeholder: '500자 이내로 입력해주세요.',
+  },
+};
+
+export const Medium500: Story = {
+  args: {
+    variant: 'limit500',
+    size: 'md',
+    fontSize: 'base',
+    border: 'blue-border',
+    borderRadius: 'xl',
+    placeholder: '500자 이내로 입력해주세요.',
+  },
+};
+
+export const Large500: Story = {
+  args: {
+    variant: 'limit500',
+    size: 'lg',
+    fontSize: 'xl',
+    border: 'blue-border',
+    borderRadius: 'xl',
+    placeholder: '500자 이내로 입력해주세요.',
+  },
+};


### PR DESCRIPTION
## ❓이슈
- close #10 

## :writing_hand: Description

text area 컴포넌트에 관한 PR입니다.

이 PR에서는 디자인 시스템에 따라 문자 수 제한 기능이 있는 TextArea 컴포넌트를 개발했습니다.

원래 figma상에서는 500자 이내로 입력해달라는 에러문구를 아래 출력해야하는데, placeholder에 이미 100자 또는 500자 이내로 입력해달라는 문구가 있어서, 글자수 제한을 실시간으로 보여주는게 유저 입장에서 더 와닿을 것 같아서, 조금 다르게 적용해서 개발했습니다.
이를위해, use-client를 써서 CSR환경에서 개발하였습니다.

또한, maxLength 인자는 이 프로젝트에서 필요 없을 것 같긴한데, 그래도 확장성을 위해 100자, 500자 고정하는 것 보다는 사용할 일이 있으면 따로 값을 입력해서 사용하는게 편하다고 생각해서 넣었습니다.


주요기능
- 100자 제한(limit100) 및 500자 제한(limit500) 두 가지 variant 지원
- 글자 수 실시간 표시 기능 구현
- 글자 수 초과 시 시각적 피드백 제공

스토리북 발췌 사진

아래는 100자 제한 text area에서 100자가 넘어갔을 때의 사진입니다.

![image](https://github.com/user-attachments/assets/cd32d0a7-bec4-496b-84c6-6f4ffd4e9a55)


## :white_check_mark: Checklist

### PR


- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
