### PR TITLE
EP-21 공용 DropdownMenu 컴포넌트 기능 구현

### DIFF
--- a/src/assets/icons/dropdown_icon.svg
+++ b/src/assets/icons/dropdown_icon.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 19.5C18.8284 19.5 19.5 18.8284 19.5 18C19.5 17.1716 18.8284 16.5 18 16.5C17.1716 16.5 16.5 17.1716 16.5 18C16.5 18.8284 17.1716 19.5 18 19.5Z" fill="#ABB8CE" stroke="#ABB8CE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 9C18.8284 9 19.5 8.32843 19.5 7.5C19.5 6.67157 18.8284 6 18 6C17.1716 6 16.5 6.67157 16.5 7.5C16.5 8.32843 17.1716 9 18 9Z" fill="#ABB8CE" stroke="#ABB8CE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 30C18.8284 30 19.5 29.3284 19.5 28.5C19.5 27.6716 18.8284 27 18 27C17.1716 27 16.5 27.6716 16.5 28.5C16.5 29.3284 17.1716 30 18 30Z" fill="#ABB8CE" stroke="#ABB8CE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ui/DropdownMenu/index.tsx
+++ b/src/components/ui/DropdownMenu/index.tsx
@@ -1,0 +1,78 @@
+"use client";
+import { useState } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/utils/cn';
+import Image from 'next/image';
+import dropdownIcon from '@/assets/icons/dropdown_icon.svg';
+
+const DropdownVariants = cva('absolute overflow-hidden', {
+  variants: {
+    variant: {
+      default: 'bg-white border border-gray-100',
+      outline: 'bg-white border border-gray-100',
+    },
+    size: {
+      sm: 'w-[100px] rounded-[10px] sm:w-[70px] md:w-[80px] lg:w-[97px] lg:rounded-[16px]',
+      md: 'w-[100px] rounded-[10px] sm:w-[100px] md:w-[120px] lg:w-[134px] lg:rounded-[16px]',
+      lg: 'w-[100px] rounded-[10px] sm:w-[120px] md:w-[130px] lg:w-[150px] lg:rounded-[16px]',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'md',
+  },
+});
+
+interface DropdownProps extends VariantProps<typeof DropdownVariants> {
+  className?: string;
+  options?: string[];
+  onSelect?: (option: string) => void;
+}
+
+export default function DropdownMenu({
+  variant,
+  size = 'md',
+  options = ["수정하기", "삭제하기"],
+  onSelect,
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const liPaddingClasses =
+    size === 'md'
+      ? 'py-2 text-md lg:py-4 lg:text-xl'
+      : size === 'sm'
+        ? 'py-2 text-xs lg:py-2 lg:text-md'
+        : size === 'lg'
+          ? 'py-2 text-md lg:py-6 lg:text-2xl'
+          : 'py-2 text-md lg:py-4 lg:text-xl';
+
+  return (
+    <div className="relative inline-block ">
+      <button onClick={() => setIsOpen(!isOpen)} className="cursor-pointer">
+        <Image src={dropdownIcon} alt="Dropdown Icon" />
+      </button>
+      {isOpen && (
+        <ul className={cn(DropdownVariants({ variant, size }),
+          'top-[45px] right-0'
+        )}>
+          {options.map((option) => (
+            <li
+              key={option}
+              onClick={() => {
+                setIsOpen(false);
+                onSelect?.(option);
+              }}
+              className={cn(
+                liPaddingClasses,
+                'hover:bg-gray-100 cursor-pointer text-center',
+                'text-[var(--color-black-800)]'
+              )}
+            >
+              {option}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/stories/DropdownMenu/index.stories.tsx
+++ b/src/stories/DropdownMenu/index.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import DropdownMenu from '@/components/ui/DropdownMenu';
+import { cn } from '@/utils/cn';
+import { Pretendard } from '@/fonts';
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'DropdownMenu',
+  component: DropdownMenu,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        className={cn(
+          'flex h-[300px] w-[500px] items-center justify-center rounded-2xl bg-gray-100',
+          Pretendard.className
+        )}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      options: ['default', 'outline'],
+      control: { type: 'select' },
+    },
+    size: {
+      options: ['sm', 'md', 'lg'],
+      control: { type: 'select' },
+    },
+    options: {
+      control: { type: 'object' },
+    },
+    onSelect: { action: 'option selected' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+export const Default: Story = {
+  args: {
+    options: ['수정하기', '삭제하기'],
+    onSelect: action('option selected'),
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: 'outline',
+    options: ['수정하기', '삭제하기'],
+    onSelect: action('option selected'),
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    options: ['수정하기', '삭제하기'],
+    onSelect: action('option selected'),
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    options: ['수정하기', '삭제하기'],
+    onSelect: action('option selected'),
+  },
+};
+
+export const CustomOptions: Story = {
+  args: {
+    options: ['Option 1', 'Option 2', 'Option 3'],
+    onSelect: action('option selected'),
+  },
+};


### PR DESCRIPTION
## ❓이슈
- close #15  

## :writing_hand: Description

해당 pr은
DropdownMenu 컴포넌트입니다.
DropdownMenu 아이콘을 클릭하면 수정하기, 삭제하기가 나오는 구조입니다.
props는 variant, size, options, onSelect 4가지를 전달 받고 있습니다.
size는 md, sm, lg 를 적용할 수 있으면 기본 md 값이 적용되어 있습니다.
options는 동적으로 받을까 하다가 디자인을 확인해보니 수정,삭제만 사용하고 있어서
내부 컴포넌트에 고정으로 적용했습니다. 나중에 다른곳에 쓰일 수 있다면 수정 진행할게요.
onSelect는 부모 컴포넌트에서 수정, 삭제 선택했을 때 로직 처리를 진행해주시면 됩니다.

해당 내용 토대로 스토리북 적용되므로 이미지 첨부해드립니다.

### 스토리북 이미지

![storybook-dropdown](https://github.com/user-attachments/assets/580c85ce-8884-46db-a0a7-c929a081bf58)

## :white_check_mark: Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes


