### PR TITLE
EP-23 공용 keyword-card 컴포넌트 기능 구현 

### DIFF
--- a/src/components/ui/Field/Input.tsx
+++ b/src/components/ui/Field/Input.tsx
@@ -8,10 +8,9 @@ export type InputProps = BaseField &
   InputHTMLAttributes<HTMLInputElement> &
   VariantProps<typeof baseFieldClassName> & {
     ref?: Ref<HTMLInputElement>;
-    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void; //Todo onChange 추가했습니다. 11번, 14번, 24번 줄 / 이유: kewordCard 사용시 글자 하이라이트 주기 위해서
   };
 
-export default function Input({ label, error, variant = 'default', className, ref, onChange, ...props }: InputProps) {
+export default function Input({ label, error, variant = 'default', className, ref, ...props }: InputProps) {
   const id = useId();
 
   return (
@@ -20,8 +19,8 @@ export default function Input({ label, error, variant = 'default', className, re
         <BaseLabel required={props.required} htmlFor={id}>
           {label}
         </BaseLabel>
-      )}{' '}
-      <input id={id} className={cn(baseFieldClassName({ variant, className }), error && BASE_ERROR_CLASSNAME)} ref={ref} onChange={onChange} {...props} />
+      )}
+      <input id={id} className={cn(baseFieldClassName({ variant, className }), error && BASE_ERROR_CLASSNAME)} ref={ref} {...props} />
       {error && <BaseError>{error}</BaseError>}
     </BaseItem>
   );

--- a/src/components/ui/Field/Input.tsx
+++ b/src/components/ui/Field/Input.tsx
@@ -8,9 +8,10 @@ export type InputProps = BaseField &
   InputHTMLAttributes<HTMLInputElement> &
   VariantProps<typeof baseFieldClassName> & {
     ref?: Ref<HTMLInputElement>;
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void; //Todo onChange 추가했습니다. 11번, 14번, 24번 줄 / 이유: kewordCard 사용시 글자 하이라이트 주기 위해서
   };
 
-export default function Input({ label, error, variant = 'default', className, ref, ...props }: InputProps) {
+export default function Input({ label, error, variant = 'default', className, ref, onChange, ...props }: InputProps) {
   const id = useId();
 
   return (
@@ -19,8 +20,8 @@ export default function Input({ label, error, variant = 'default', className, re
         <BaseLabel required={props.required} htmlFor={id}>
           {label}
         </BaseLabel>
-      )}
-      <input id={id} className={cn(baseFieldClassName({ variant, className }), error && BASE_ERROR_CLASSNAME)} ref={ref} {...props} />
+      )}{' '}
+      <input id={id} className={cn(baseFieldClassName({ variant, className }), error && BASE_ERROR_CLASSNAME)} ref={ref} onChange={onChange} {...props} />
       {error && <BaseError>{error}</BaseError>}
     </BaseItem>
   );

--- a/src/components/ui/keywordCard/index.tsx
+++ b/src/components/ui/keywordCard/index.tsx
@@ -27,10 +27,10 @@ const KeywordCard = ({ text, author, hashtags, inputText }: KeywordCardProps) =>
     <div className='h-37 w-full border-b border-gray-100 p-4 pt-4 pr-6 pb-4 pl-6 md:h-[152px] lg:h-[176px] lg:p-6'>
       <div className='flex h-29 flex-col justify-between md:h-[120px] lg:h-[128px]'>
         <div className='flex h-20.5 w-full flex-col justify-between lg:h-[80px]'>
-          <p className={`${Iropke.className} --text-xl h-13 overflow-hidden text-[16px] leading-[26px] font-normal lg:h-[28px] lg:text-xl`}>{highlightText(text)}</p>
-          <p className={`${Iropke.className} h-6.5 text-sm text-[16px] leading-[26px] font-normal text-gray-400 lg:h-[28px] lg:text-xl`}>- {highlightText(author)} -</p>
+          <p className={`${Iropke.className} h-13 overflow-hidden text-lg font-normal lg:h-[28px] lg:text-xl`}>{highlightText(text)}</p>
+          <p className={`${Iropke.className} h-6.5 text-lg font-normal text-gray-400 lg:h-[28px] lg:text-xl`}>- {highlightText(author)} -</p>
         </div>
-        <p className={`${Pretendard.className} flex h-6.5 justify-end overflow-hidden text-sm text-[16px] leading-[26px] font-normal text-blue-400 lg:h-[32px] lg:text-[20px] lg:leading-[32px]`}>
+        <p className={`${Pretendard.className} flex h-6.5 justify-end overflow-hidden text-lg font-normal text-blue-400 lg:h-[32px] lg:text-xl`}>
           <span className='flex max-w-full flex-nowrap gap-3 overflow-hidden'>
             {hashtags.map((tag, index) => (
               <span key={index} className='whitespace-nowrap'>

--- a/src/components/ui/keywordCard/index.tsx
+++ b/src/components/ui/keywordCard/index.tsx
@@ -1,4 +1,4 @@
-import { Iropke, Pretendard } from '../../../fonts/index';
+import { Iropke, Pretendard } from '@/fonts';
 
 interface KeywordCardProps {
   text: string;
@@ -27,8 +27,8 @@ const KeywordCard = ({ text, author, hashtags, inputText }: KeywordCardProps) =>
     <div className='h-37 w-full border-b border-gray-100 p-4 pt-4 pr-6 pb-4 pl-6 md:h-[152px] lg:h-[176px] lg:p-6'>
       <div className='flex h-29 flex-col justify-between md:h-[120px] lg:h-[128px]'>
         <div className='flex h-20.5 w-full flex-col justify-between lg:h-[80px]'>
-          <p className={`${Iropke.className} --text-xl h-13 overflow-hidden text-[16px] leading-[26px] font-normal lg:h-[28px] lg:text-[20px] lg:leading-[28px]`}>{highlightText(text)}</p>
-          <p className={`${Iropke.className} h-6.5 text-sm text-[16px] leading-[26px] font-normal text-gray-400 lg:h-[28px] lg:text-[20px] lg:leading-[28px]`}>- {highlightText(author)} -</p>
+          <p className={`${Iropke.className} --text-xl h-13 overflow-hidden text-[16px] leading-[26px] font-normal lg:h-[28px] lg:text-xl`}>{highlightText(text)}</p>
+          <p className={`${Iropke.className} h-6.5 text-sm text-[16px] leading-[26px] font-normal text-gray-400 lg:h-[28px] lg:text-xl`}>- {highlightText(author)} -</p>
         </div>
         <p className={`${Pretendard.className} flex h-6.5 justify-end overflow-hidden text-sm text-[16px] leading-[26px] font-normal text-blue-400 lg:h-[32px] lg:text-[20px] lg:leading-[32px]`}>
           <span className='flex max-w-full flex-nowrap gap-3 overflow-hidden'>

--- a/src/components/ui/keywordCard/index.tsx
+++ b/src/components/ui/keywordCard/index.tsx
@@ -1,3 +1,5 @@
+import { Iropke, Pretendard } from '../../../fonts/index';
+
 interface KeywordCardProps {
   text: string;
   author: string;
@@ -22,18 +24,20 @@ const KeywordCard = ({ text, author, hashtags, inputText }: KeywordCardProps) =>
   };
 
   return (
-    <div className='h-37 p-4 pt-4 pr-6 pb-4 pl-6 w-full border-b border-gray-100 md:h-[152px] lg:h-[176px] lg:p-6'>
-      <div className='flex h-29 flex-col justify-between md:h-[120px] lg:h-[128px]' >
+    <div className='h-37 w-full border-b border-gray-100 p-4 pt-4 pr-6 pb-4 pl-6 md:h-[152px] lg:h-[176px] lg:p-6'>
+      <div className='flex h-29 flex-col justify-between md:h-[120px] lg:h-[128px]'>
         <div className='flex h-20.5 w-full flex-col justify-between lg:h-[80px]'>
-          <p className='h-13 overflow-hidden lg:h-[28px]'>{highlightText(text)}</p>
-          <p className='h-6.5 text-sm text-gray-500 lg:h-[28px]'>- {highlightText(author)} -</p>
-        </div>  
-        <p className='flex h-6.5 justify-end text-sm text-blue-500 overflow-hidden whitespace-nowrap lg:h-[32px]'>
-          {hashtags.map((tag, index) => (
-            <span key={index} className={index !== hashtags.length - 1 ? 'mr-3' : ''}>
-              #{highlightText(tag)}{' '}
-            </span>
-          ))}
+          <p className={`${Iropke.className} --text-xl h-13 overflow-hidden text-[16px] leading-[26px] font-normal lg:h-[28px] lg:text-[20px] lg:leading-[28px]`}>{highlightText(text)}</p>
+          <p className={`${Iropke.className} h-6.5 text-sm text-[16px] leading-[26px] font-normal text-gray-400 lg:h-[28px] lg:text-[20px] lg:leading-[28px]`}>- {highlightText(author)} -</p>
+        </div>
+        <p className={`${Pretendard.className} flex h-6.5 justify-end overflow-hidden text-sm text-[16px] leading-[26px] font-normal text-blue-400 lg:h-[32px] lg:text-[20px] lg:leading-[32px]`}>
+          <span className='flex max-w-full flex-nowrap gap-3 overflow-hidden'>
+            {hashtags.map((tag, index) => (
+              <span key={index} className='whitespace-nowrap'>
+                #{highlightText(tag)}
+              </span>
+            ))}
+          </span>
         </p>
       </div>
     </div>

--- a/src/components/ui/keywordCard/index.tsx
+++ b/src/components/ui/keywordCard/index.tsx
@@ -1,0 +1,43 @@
+interface KeywordCardProps {
+  text: string;
+  author: string;
+  hashtags: string[];
+  inputText: string;
+}
+
+const KeywordCard = ({ text, author, hashtags, inputText }: KeywordCardProps) => {
+  const highlightText = (content: string) => {
+    if (!inputText) return content;
+
+    const regex = new RegExp(`(${inputText})`, 'gi'); // 입력값과 일치하는 부분 찾기
+    return content.split(regex).map((part, index) =>
+      part.toLowerCase() === inputText.toLowerCase() ? (
+        <span key={index} className='text-[rgba(81,149,238,1)]'>
+          {part}
+        </span>
+      ) : (
+        part
+      ),
+    );
+  };
+
+  return (
+    <div className='h-37 p-4 pt-4 pr-6 pb-4 pl-6 w-full border-b border-gray-100 md:h-[152px] lg:h-[176px] lg:p-6'>
+      <div className='flex h-29 flex-col justify-between md:h-[120px] lg:h-[128px]' >
+        <div className='flex h-20.5 w-full flex-col justify-between lg:h-[80px]'>
+          <p className='h-13 overflow-hidden lg:h-[28px]'>{highlightText(text)}</p>
+          <p className='h-6.5 text-sm text-gray-500 lg:h-[28px]'>- {highlightText(author)} -</p>
+        </div>  
+        <p className='flex h-6.5 justify-end text-sm text-blue-500 overflow-hidden whitespace-nowrap lg:h-[32px]'>
+          {hashtags.map((tag, index) => (
+            <span key={index} className={index !== hashtags.length - 1 ? 'mr-3' : ''}>
+              #{highlightText(tag)}{' '}
+            </span>
+          ))}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default KeywordCard;

--- a/src/stories/keywordCard/index.stories.tsx
+++ b/src/stories/keywordCard/index.stories.tsx
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react';
+import KeywordCard from '../../components/ui/keywordCard';
+import InputComponent from '../../components/ui/Field/Input';
+
+const KeywordCardStory = {
+  title: 'Components/KeywordCard',
+  component: KeywordCard,
+  argTypes: {
+    text: { control: 'text' },
+    author: { control: 'text' },
+    hashtags: { control: 'array' },
+    inputText: { control: 'text' },
+  },
+};
+
+export default KeywordCardStory;
+
+interface KeywordCardStoryArgs {
+  text: string;
+  author: string;
+  hashtags: string[];
+  inputText: string;
+}
+
+export const Default = (args: KeywordCardStoryArgs) => {
+  const [inputText, setInputText] = useState(args.inputText);
+
+  // `inputText`가 `args.inputText`로 변경될 때마다 `inputText` 상태 업데이트
+  useEffect(() => {
+    setInputText(args.inputText);
+  }, [args.inputText]);
+
+  return (
+    <div className="space-y-4">
+      <InputComponent
+        label="Keyword Input"
+        value={inputText}  // inputText를 value로 연결
+        onChange={(e) => setInputText(e.target.value)}  // inputText 상태 업데이트
+        placeholder="Enter keyword to highlight"
+      />
+
+      <KeywordCard
+        text={args.text}
+        author={args.author}
+        hashtags={args.hashtags}
+        inputText={inputText}  // inputText 전달
+      />
+    </div>
+  );
+};
+
+// 기본값 설정
+Default.args = {
+  text: '예제 글입니다.',
+  author: '홍길동',
+  hashtags: ['React', 'Storybook', 'test', '한글은?'],
+  inputText: '',  // 기본값 설정
+};


### PR DESCRIPTION
## ❓이슈
- close #17 

## :writing_hand: Description

공용 keyword-card 컴포넌트 기능
인풋 검색창에 단어 입력시에 일치하는 단어라면 글자 색이 바뀌게 작업했습니다.
그러기 위해서 **input 공용컴포넌트에 onChange도 props로 받게 수정**하고 주석 남겨놨습니다


```js
      <InputComponent
        label="Keyword Input"
        value={inputText}  // inputText를 value로 연결
        onChange={(e) => setInputText(e.target.value)}  //  다음과 같이 onChange 받게했습니다.
        placeholder="Enter keyword to highlight"
      />

```

그리고 사용하시는 부모 컴포넌트에서  const [inputText, setInputText] = useState(args.inputText); 
상태 명시해주시고
```js

    <KeywordCard
        text={args.text}
        author={args.author}
        hashtags={args.hashtags}
        inputText={inputText}  // inputText 전달
      />

```

처럼 사용 해주시면 되겠습니다. 






https://github.com/user-attachments/assets/71df8238-8fc5-4f85-b68d-9c8f1158184f






<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
