### PR TITLE
EP-40 공용 toggle-btn 컴포넌트 기능 구현

### DIFF
--- a/src/components/ui/toggleBtn/index.tsx
+++ b/src/components/ui/toggleBtn/index.tsx
@@ -5,9 +5,15 @@ interface ToggleButtonProps {
   isPublic: boolean;
   onToggle: (newState: boolean) => void;
   size?: 'small' | 'medium';
+  label?: string; // label 추가해서 성락님 의견대로 커스텀 가능하게 했습니다.
 }
 
-const ToggleButton: React.FC<ToggleButtonProps> = ({ isPublic, onToggle, size = 'medium' }) => {
+const ToggleButton: React.FC<ToggleButtonProps> = ({
+  isPublic,
+  onToggle,
+  size = 'medium',
+  label = '공개'
+}) => {
   const sizeClasses = {
     small: 'w-8 h-4', 
     medium: 'w-10.5 h-6', 
@@ -23,16 +29,15 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({ isPublic, onToggle, size = 
     medium: 'text-sm', 
   };
 
-
   const togglePosition = {
     small: isPublic ? 'left-[calc(100%-14px)]' : 'left-1',  
     medium: isPublic ? 'left-[calc(100%-20px)]' : 'left-1', 
   };
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="inline-flex items-center gap-2">
       <span className={`${Pretendard.className} text-gray-400 font-semibold ${textSize[size]}`}>
-        공개
+        {label}
       </span>
 
       <button

--- a/src/components/ui/toggleBtn/index.tsx
+++ b/src/components/ui/toggleBtn/index.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Pretendard } from '@/fonts';
+
+interface ToggleButtonProps {
+  isPublic: boolean;
+  onToggle: (newState: boolean) => void;
+  size?: 'small' | 'medium';
+}
+
+const ToggleButton: React.FC<ToggleButtonProps> = ({ isPublic, onToggle, size = 'medium' }) => {
+  const sizeClasses = {
+    small: 'w-8 h-4', 
+    medium: 'w-10.5 h-6', 
+  };
+
+  const circleSize = {
+    small: 'w-2.5 h-2.5', 
+    medium: 'w-4 h-4', 
+  };
+
+  const textSize = {
+    small: 'text-xs',  
+    medium: 'text-sm', 
+  };
+
+
+  const togglePosition = {
+    small: isPublic ? 'left-[calc(100%-14px)]' : 'left-1',  
+    medium: isPublic ? 'left-[calc(100%-20px)]' : 'left-1', 
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className={`${Pretendard.className} text-gray-400 font-semibold ${textSize[size]}`}>
+        공개
+      </span>
+
+      <button
+        onClick={() => onToggle(!isPublic)}
+        className={`relative flex items-center px-1 ${sizeClasses[size]} rounded-full 
+          ${isPublic ? 'bg-black-600' : 'bg-gray-300'} transition-colors duration-500 ease-in-out`}
+      >
+        <span
+          className={`absolute bg-white rounded-full ${circleSize[size]} shadow-md transition-transform duration-1000 ease-in-out
+            ${togglePosition[size]}`}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default ToggleButton;

--- a/src/stories/toggleBtn/index.stories.tsx
+++ b/src/stories/toggleBtn/index.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import ToggleBtn from '@/components/ui/toggleBtn'; 
+import ToggleBtn from '@/components/ui/toggleBtn';
 import { Meta, StoryFn } from '@storybook/react';
 
 export default {
@@ -32,25 +32,23 @@ const Template: StoryFn = (args) => {
     setIsPublic(args.isPublic);
   }, [args.isPublic]);
 
-  return (
-    <ToggleBtn
-      {...args}
-      isPublic={isPublic}
-      onToggle={handleToggle}
-    />
-  );
+  return <ToggleBtn {...args} isPublic={isPublic} onToggle={handleToggle} />;
 };
 
 export const Default = Template.bind({});
 Default.args = {
   size: 'medium',
   isPublic: false,
-  onToggle: (newState: boolean) => { console.log("New state:", newState); },
+  onToggle: (newState: boolean) => {
+    console.log('New state:', newState);
+  },
 };
 
 export const Small = Template.bind({});
 Small.args = {
   size: 'small',
   isPublic: false,
-  onToggle: (newState: boolean) => { console.log("New state:", newState); },
+  onToggle: (newState: boolean) => {
+    console.log('New state:', newState);
+  },
 };

--- a/src/stories/toggleBtn/index.stories.tsx
+++ b/src/stories/toggleBtn/index.stories.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import ToggleBtn from '@/components/ui/toggleBtn'; 
+import { Meta, StoryFn } from '@storybook/react';
+
+export default {
+  title: 'Components/ToggleButton',
+  component: ToggleBtn,
+  argTypes: {
+    size: {
+      control: {
+        type: 'radio',
+        options: ['small', 'medium'],
+      },
+      defaultValue: 'medium',
+    },
+    isPublic: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+  },
+} as Meta;
+
+const Template: StoryFn = (args) => {
+  const [isPublic, setIsPublic] = useState(args.isPublic);
+
+  const handleToggle = (newState: boolean) => {
+    setIsPublic(newState);
+    args.onToggle(newState);
+  };
+
+  useEffect(() => {
+    setIsPublic(args.isPublic);
+  }, [args.isPublic]);
+
+  return (
+    <ToggleBtn
+      {...args}
+      isPublic={isPublic}
+      onToggle={handleToggle}
+    />
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  size: 'medium',
+  isPublic: false,
+  onToggle: (newState: boolean) => { console.log("New state:", newState); },
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  size: 'small',
+  isPublic: false,
+  onToggle: (newState: boolean) => { console.log("New state:", newState); },
+};


### PR DESCRIPTION
## ❓이슈
- close #39 

## :writing_hand: Description

공용 toggle- btn 기능을 제작했습니다
사이즈는 small, medium으로 두 가지 존재합니다. 
inline-flex를 주어 내부 텍스트가 길어짐에따라 늘어나게 수정했습니다. 


사용법은 
부모 컴포넌트에서 상태를 관리하고, 그 상태를 ToggleButton에 전달하여 버튼이 상태를 토글하도록 설정합니다.

+ 추가적으로 성락님 의견대로 text를 props로 받아 커스텀 가능하게 수정했습니다! (labels) 값 주면 됩니다 

## 스토리북 영상 참고 
(영상에서는 길이 늘어남에따라 규격 맞춰지는 것을 보여주기 위해 bg 넣어준 것이며 지우고 올렸습니다)

https://github.com/user-attachments/assets/b875086e-90aa-46dd-b8be-c92199e49a84








<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
