### PR TITLE
EP-39 공용 radio button 컴포넌트 구현 

### DIFF
--- a/src/components/ui/radio/RadioGroup.tsx
+++ b/src/components/ui/radio/RadioGroup.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+import { HTMLAttributes, ReactNode, createContext, useState } from 'react';
+
+interface RadioGroupContextValue {
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const RadioGroupContext = createContext<RadioGroupContextValue | null>(null);
+
+export interface RadioGroupProps extends HTMLAttributes<HTMLDivElement> {
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  name?: string;
+  children: ReactNode;
+}
+
+export function RadioGroup({ defaultValue = '', onValueChange, name = 'radio-group', children, className, ...props }: RadioGroupProps) {
+  const [value, setValue] = useState(defaultValue);
+
+  const handleChange = (val: string) => {
+    setValue(val);
+    if (onValueChange) onValueChange(val);
+  };
+
+  return (
+    <RadioGroupContext.Provider value={{ name, value, onChange: handleChange }}>
+      <div className={cn('flex gap-6', className)} {...props}>
+        {children}
+      </div>
+    </RadioGroupContext.Provider>
+  );
+}
+
+export { RadioGroupContext };

--- a/src/components/ui/radio/RadioGroupItem.tsx
+++ b/src/components/ui/radio/RadioGroupItem.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { cva } from 'class-variance-authority';
+import { InputHTMLAttributes, useContext } from 'react';
+import { RadioGroupContext } from './RadioGroup';
+import { cn } from '@/utils/cn';
+
+const radioGroupItemVariants = cva('relative flex items-center justify-center rounded-full border border-blue-300 border-2', {
+  variants: {
+    radioSize: {
+      sm: 'w-5 h-5',
+      md: 'w-6 h-6',
+    },
+  },
+  defaultVariants: {
+    radioSize: 'md',
+  },
+});
+
+export interface RadioGroupItemProps extends InputHTMLAttributes<HTMLInputElement> {
+  value: string;
+  radioSize?: 'sm' | 'md';
+  id: string;
+}
+
+export function RadioGroupItem({ value, radioSize = 'md', id, className, ...props }: RadioGroupItemProps) {
+  const context = useContext(RadioGroupContext);
+
+  if (!context) {
+    throw new Error('RadioGroupItem은 RadioGroup 내에서 사용해야 합니다.');
+  }
+
+  const { name, value: selectedValue, onChange } = context;
+  const checked = selectedValue === value;
+
+  return (
+    <>
+      <input type='radio' id={id} name={name} value={value} checked={checked} onChange={() => onChange(value)} className='hidden' {...props} />
+      <div onClick={() => onChange(value)} className={cn(radioGroupItemVariants({ radioSize }), className)}>
+        {checked && <div className='h-3 w-3 rounded-full bg-blue-800' />}
+      </div>
+    </>
+  );
+}

--- a/src/components/ui/radio/RadioItem.tsx
+++ b/src/components/ui/radio/RadioItem.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import { RadioGroupItem } from './RadioGroupItem';
+import { RadioLabel } from './RadioLabel';
+
+export interface RadioItemProps {
+  value: string;
+  id: string;
+  radioSize?: 'sm' | 'md';
+  label: string;
+}
+
+export function RadioItem({ value, id, radioSize = 'md', label }: RadioItemProps) {
+  const fontSizeClass = radioSize === 'sm' ? 'text-lg' : 'text-xl';
+
+  return (
+    <div className='flex items-center gap-2 space-x-2'>
+      <RadioGroupItem value={value} id={id} radioSize={radioSize} />
+      <RadioLabel htmlFor={id} className={fontSizeClass}>
+        {label}
+      </RadioLabel>
+    </div>
+  );
+}

--- a/src/components/ui/radio/RadioLabel.tsx
+++ b/src/components/ui/radio/RadioLabel.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { HTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/utils/cn';
+
+export interface RadioLabelProps extends HTMLAttributes<HTMLLabelElement> {
+  htmlFor: string;
+  children: ReactNode;
+}
+
+export function RadioLabel({ htmlFor, children, className, ...props }: RadioLabelProps) {
+  return (
+    <label htmlFor={htmlFor} className={cn('text-black-600 cursor-pointer font-medium', className)} {...props}>
+      {children}
+    </label>
+  );
+}

--- a/src/stories/radio/radioGroup.stories.tsx
+++ b/src/stories/radio/radioGroup.stories.tsx
@@ -1,0 +1,44 @@
+import React, { ComponentProps, useState } from 'react';
+import { RadioGroup } from '@/components/ui/radio/RadioGroup';
+import { RadioItem } from '@/components/ui/radio/RadioItem';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Radio/RadioGroup',
+  component: RadioGroup,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'RadioGroup 컴포넌트는 여러 RadioItem들을 그룹화하여 하나의 선택 그룹을 형성합니다. 내부 상태를 관리하며, 사용자가 선택을 변경할 때 onValueChange 콜백을 통해 변경된 값을 외부로 전달합니다.',
+      },
+    },
+  },
+
+  argTypes: {
+    defaultValue: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioGroup>;
+
+const DefaultTemplate = (args: ComponentProps<typeof RadioGroup>) => {
+  const [selected, setSelected] = useState(args.defaultValue || 'option1');
+  return (
+    <RadioGroup defaultValue={selected} onValueChange={setSelected} {...args}>
+      <RadioItem value='option1' id='option1' radioSize='md' label='옵션 1' />
+      <RadioItem value='option2' id='option2' radioSize='md' label='옵션 2' />
+      <RadioItem value='option3' id='option3' radioSize='md' label='옵션 3' />
+    </RadioGroup>
+  );
+};
+
+export const Default: Story = {
+  render: DefaultTemplate,
+  args: {
+    defaultValue: 'option1',
+  },
+};

--- a/src/stories/radio/radioItem.stories.tsx
+++ b/src/stories/radio/radioItem.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RadioItem } from '@/components/ui/radio/RadioItem';
+import { RadioGroup } from '@/components/ui/radio/RadioGroup';
+
+const meta: Meta<typeof RadioItem> = {
+  title: 'Radio/RadioItem',
+  component: RadioItem,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'RadioItem 컴포넌트는 단일 라디오 버튼 항목을 렌더링합니다. RadioGroup 컨테이너 내에서 사용되며, 버튼과 함께 라벨을 표시하여 선택 상태를 쉽게 확인할 수 있도록 도와줍니다.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div role='radiogroup' className='flex flex-col gap-2 rounded bg-gray-100 p-4'>
+        <RadioGroup>
+          <Story />
+        </RadioGroup>
+      </div>
+    ),
+  ],
+  argTypes: {
+    radioSize: {
+      options: ['sm', 'md'],
+      control: { type: 'select' },
+    },
+    label: { control: 'text' },
+    value: { control: 'text' },
+    id: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioItem>;
+
+export const Default: Story = {
+  args: {
+    id: 'option1',
+    value: 'option1',
+    label: '옵션 1',
+    radioSize: 'md',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    id: 'option2',
+    value: 'option2',
+    label: '옵션 2 (Small)',
+    radioSize: 'sm',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    id: 'option3',
+    value: 'option3',
+    label: '옵션 3 (Medium)',
+    radioSize: 'md',
+  },
+};


### PR DESCRIPTION
## ❓이슈
- close #38 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
- RadioGroup을 부모 컴포넌트로 사용하여 하위에 여러 RadioItem들을 배치합니다.
- RadioGroup에 defaultValue와 선택 변경 시 실행할 onValueChange 콜백 함수를 전달합니다.
- 각 RadioItem은 value, id, label, 그리고 선택 시 버튼의 크기를 지정할 radioSize 등의 props를 전달받아 렌더링됩니다.

- Context 사용: RadioGroup은 RadioGroupContext를 통해 현재 선택된 값과 상태 변경 함수를 하위 컴포넌트에 제공합니다. 이로 인해 RadioItem은 별도의 상태 관리 없이 컨텍스트를 통해 그룹의 상태를 공유하게 됩니다.
- 유의사항: RadioItem은 RadioGroup 내에서만 정상적으로 동작하도록 설계되었습니다. 독립적으로 사용 시 컨텍스트가 전달되지 않아 의도한 대로 작동하지 않으므로, 항상 RadioGroup 내부에서 사용해야 합니다.

<img width="648" alt="스크린샷 2025-03-13 20 03 23" src="https://github.com/user-attachments/assets/78a47496-c9f3-4db2-b92b-42887ebb86e4" />
<img width="631" alt="스크린샷 2025-03-13 20 03 39" src="https://github.com/user-attachments/assets/272665ff-6fdc-4206-b50a-65a71703b7b7" />


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
