### PR TITLE
EP-47 공용 side-bar 컴포넌트 리팩토링 (비즈니스 로직 제거 및 재사용성)

### DIFF
--- a/src/components/ui/sideBar/index.tsx
+++ b/src/components/ui/sideBar/index.tsx
@@ -5,56 +5,63 @@ import sideBarIcon from '@/assets/icons/sideBar.svg';
 import closeIcon from '@/assets/icons/X.svg';
 
 export interface SideBarProps {
-  onSelectedTab: (tab: 'feed' | 'search') => void;
+  items: { label: string; value: string }[]; // 메뉴를 동적으로 받기
+  onSelect: (value: string) => void; // 메뉴 선택 시 실행될 함수
   isOpen?: boolean;
 }
 
-export default function SideBar({ onSelectedTab, isOpen = false }: SideBarProps) {
+export default function SideBar({ items, onSelect, isOpen = false }: SideBarProps) {
   const [isopen, setIsOpen] = useState(isOpen);
   const toggleSidebar = () => setIsOpen(!isopen);
-
-  const handleTabSelect = (tab: 'feed' | 'search') => {
-    onSelectedTab(tab); // 상위 컴포넌트로 선택된 탭 전달
-    setIsOpen(false); // 사이드바 닫기
-  };
 
   useEffect(() => {
     setIsOpen(isOpen);
   }, [isOpen]);
 
   return (
-    <React.Fragment>
+    <>
       {/* 햄버거 버튼 */}
-      <button className='flex h-6 w-6 items-center justify-center' onClick={toggleSidebar}>
-        <Image src={sideBarIcon} alt='sideBarIcon' width={18} height={12} />
+      <button className="flex h-6 w-6 items-center justify-center" onClick={toggleSidebar}>
+        <Image src={sideBarIcon} alt="sideBarIcon" width={18} height={12} />
       </button>
 
       {/* 오버레이 */}
-      {isopen && <div className='absolute inset-0' style={{ backgroundColor: 'rgba(0, 0, 0, 0.6)' }} onClick={toggleSidebar}></div>}
+      {isopen && (
+        <div className="absolute inset-0 bg-black bg-opacity-60" onClick={toggleSidebar}></div>
+      )}
 
       {/* 사이드바 */}
       <motion.div
-        initial={{ x: '-100%' }} // 사이드바 시작 위치
-        animate={{ x: isopen ? 0 : '-100%' }} // 사이드바가 열리고 닫힐 때의 애니메이션
+        initial={{ x: '-100%' }}
+        animate={{ x: isopen ? 0 : '-100%' }}
         transition={{ type: 'spring', stiffness: 20 }}
-        className='fixed top-0 bottom-0 left-0 w-55 bg-blue-100 text-black'
+        className="fixed top-0 bottom-0 left-0 w-55 bg-blue-100 text-black"
       >
-        <div className='w-55'>
-          <div className='flex h-12.5 w-full items-center justify-center border-b border-gray-100'>
-            <div className='flex h-6 w-47 justify-end'>
-              <Image src={closeIcon} alt='xIcon' width={24} height={24} onClick={toggleSidebar} />
+        <div className="w-55">
+          {/* 닫기 버튼 */}
+          <div className="flex h-12.5 w-full items-center justify-center border-b border-gray-100">
+            <div className="flex h-6 w-47 justify-end">
+              <Image src={closeIcon} alt="xIcon" width={24} height={24} onClick={toggleSidebar} />
             </div>
           </div>
-        </div>
-        <div className='h-37'>
-          <div className='ml-5 flex h-18.5 items-center' onClick={() => handleTabSelect('feed')}>
-            <p className='h-6.5 w-7'>피드</p>
-          </div>
-          <div className='ml-5 flex h-18.5 items-center' onClick={() => handleTabSelect('search')}>
-            <p className='h-6.5 w-7'>검색</p>
+
+          {/* 동적으로 메뉴 렌더링 */}
+          <div className="h-37">
+            {items.map((item) => (
+              <div
+                key={item.value}
+                className="ml-5 flex h-18.5 items-center cursor-pointer"
+                onClick={() => {
+                  onSelect(item.value);
+                  setIsOpen(false);
+                }}
+              >
+                <p className="h-6.5 w-7">{item.label}</p>
+              </div>
+            ))}
           </div>
         </div>
       </motion.div>
-    </React.Fragment>
+    </>
   );
 }

--- a/src/stories/sideBar/index.stories.tsx
+++ b/src/stories/sideBar/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import SideBar from '../../components/ui/sideBar';
+import SideBar from '@/components/ui/sideBar';
 import { action } from '@storybook/addon-actions';
 
 const meta: Meta<typeof SideBar> = {
@@ -9,20 +9,25 @@ const meta: Meta<typeof SideBar> = {
     viewport: { defaultViewport: 'mobile1' },
   },
   argTypes: {
-    onSelectedTab: { 
-      action: 'onSelectedTab', // action 정의
-    },
+    onSelect: { action: 'onSelect' },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof SideBar>;
 
+const sampleItems = [
+  { label: '피드', value: 'feed' },
+  { label: '검색', value: 'search' },
+  { label: '설정', value: 'settings' },
+];
+
 export const Default: Story = {
   args: {
-    onSelectedTab: (tab) => {
+    items: sampleItems,
+    onSelect: (tab) => {
       console.log(`Selected Tab: ${tab}`);
-      action('onSelectedTab')(tab);
+      action('onSelect')(tab);
     },
     isOpen: false,
   },
@@ -30,14 +35,16 @@ export const Default: Story = {
 
 export const Open: Story = {
   args: {
-    onSelectedTab: action('onSelectedTab'),
+    items: sampleItems,
+    onSelect: action('onSelect'),
     isOpen: true,
   },
 };
 
 export const Closed: Story = {
   args: {
-    onSelectedTab: action('onSelectedTab'),
+    items: sampleItems,
+    onSelect: action('onSelect'),
     isOpen: false,
   },
 };


### PR DESCRIPTION
## ❓이슈
- close #49 

## :writing_hand: Description

멘토링 시간에 멘토님이 피드백 주셨던 내용을 리팩토링해서 코드 수정을 했습니다.

# 메뉴 항목을 동적으로 받도록 수정:

이전에는 피드, 검색과 같은 고정된 메뉴 항목을 컴포넌트 내에 하드코딩했습니다. 

이를 items prop으로 받아서 메뉴 항목을 외부에서 동적으로 전달할 수 있도록 변경했습니다.

# 메뉴 항목 선택 시 비즈니스 로직 제거:

메뉴 클릭 시 바로 비즈니스 로직을 처리하던 부분을, 

메뉴 항목을 선택할 때마다 onSelect 함수를 호출하도록 수정하여, 비즈니스 로직은 부모 컴포넌트에서 처리하도록 했습니다.

SideBar는 이제 단순히 UI 역할만 하며, 메뉴 항목의 선택은 외부에서 전달된 onSelect 함수로 처리됩니다.

# 컴포넌트 재사용성 강화:

메뉴 항목을 외부에서 유연하게 받을 수 있게 되어, 다양한 메뉴를 가진 사이드바를 쉽게 구현할 수 있게 되었습니다. 

예를 들어, items 배열에 다른 메뉴 항목을 전달하면, 해당 항목들이 자동으로 렌더링됩니다.

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
