### PR TITLE
EP-22 textcard 컴포넌트 구현

### DIFF
--- a/src/components/ui/textarea/index.tsx
+++ b/src/components/ui/textarea/index.tsx
@@ -52,14 +52,16 @@ export default function TextArea({ variant, size, fontSize, border, borderRadius
 
   const [charCount, setCharCount] = useState(initialValue.length);
 
-  let charLimit = variant === 'limit100' ? 100 : variant === 'limit500' ? 500 : null;
+  let charLimit = 0;
 
   if (variant === 'limit100') {
     charLimit = 100;
   } else if (variant === 'limit500') {
     charLimit = 500;
-  } else {
-    charLimit = null;
+  }
+
+  if (isNaN(charLimit)) {
+    charLimit = 0;
   }
 
   const effectiveMaxLength = maxLength || charLimit || undefined;
@@ -91,7 +93,7 @@ export default function TextArea({ variant, size, fontSize, border, borderRadius
         {...props}
       />
 
-      {charLimit && (
+      {charLimit > 0 && (
         <div className={charCountContainerStyle}>
           <span className={charCount >= charLimit ? 'text-red-500' : 'text-gray-500'}>{charCount}</span>
           <span className='text-gray-500'>/{charLimit}</span>

--- a/src/components/ui/textarea/index.tsx
+++ b/src/components/ui/textarea/index.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@/utils/cn';
 import { cva, VariantProps } from 'class-variance-authority';
-import { TextareaHTMLAttributes, useState, ChangeEvent } from 'react';
+import { TextareaHTMLAttributes, useState, ChangeEvent, Ref } from 'react';
 
 const textAreaVariants = cva('bg-white placeholder-blue-300', {
   variants: {
@@ -42,16 +42,26 @@ const textAreaVariants = cva('bg-white placeholder-blue-300', {
 
 const charCountContainerStyle = 'absolute -bottom-4 right-0 text-xs flex items-center';
 
-interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>, VariantProps<typeof textAreaVariants> {
+export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>, VariantProps<typeof textAreaVariants> {
   maxLength?: number;
+  ref?: Ref<HTMLTextAreaElement>;
 }
 
-export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ...props }: TextAreaProps) {
+export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ref, ...props }: TextAreaProps) {
   const initialValue = value?.toString() || defaultValue?.toString() || '';
 
   const [charCount, setCharCount] = useState(initialValue.length);
 
-  const charLimit = variant === 'limit100' ? 100 : variant === 'limit500' ? 500 : null;
+  let charLimit = variant === 'limit100' ? 100 : variant === 'limit500' ? 500 : null;
+
+  if (variant === 'limit100') {
+    charLimit = 100;
+  } else if (variant === 'limit500') {
+    charLimit = 500;
+  } else {
+    charLimit = null;
+  }
+
   const effectiveMaxLength = maxLength || charLimit || undefined;
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -77,6 +87,7 @@ export default function TextArea({ variant, size, fontSize, border, borderRadius
         maxLength={effectiveMaxLength}
         value={value}
         defaultValue={defaultValue}
+        ref={ref}
         {...props}
       />
 

--- a/src/components/ui/textcard/index.tsx
+++ b/src/components/ui/textcard/index.tsx
@@ -135,7 +135,7 @@ export default function TextCard({ isDropdown, cardContent, author, tags = [], m
     >
       <div>
         <div className='p-[22px]'>
-          <div className='mb-4'>{cardContent}</div>
+          <div className='mb-4 line-clamp-4'>{cardContent}</div>
 
           {author && <div className='text-right text-blue-400'>- {author} -</div>}
         </div>

--- a/src/components/ui/textcard/index.tsx
+++ b/src/components/ui/textcard/index.tsx
@@ -1,0 +1,165 @@
+import { cva, VariantProps } from 'class-variance-authority';
+import { HTMLAttributes } from 'react';
+import { Iropke } from '@/fonts';
+import dropdown_icon from '@/assets/icons/dropdown_icon.svg';
+import Image from 'next/image';
+
+const textCardVariants = cva(`border border-line-100 border-solid rounded-xl font-normal ${Iropke.className}`, {
+  variants: {
+    variant: {
+      fixedHeight: '',
+      variableHeight: 'min-h-[106px]',
+    },
+
+    width: {
+      w286: 'w-[286px]',
+      w294: 'w-[294px]',
+      w312: 'w-[312px]',
+      w366: 'w-[366px]',
+      w384: 'w-[384px]',
+      w472: 'w-[472px]',
+      w540: 'w-[540px]',
+      w585: 'w-[585px]',
+      w640: 'w-[640px]',
+      w744: 'w-[744px]',
+    },
+
+    fixedSize: {
+      w294h180: 'w-[294px] h-[180px]',
+      w312h140: 'w-[312px] h-[140px]',
+      w585h259: 'w-[585px] h-[259px]',
+    },
+
+    tagPosition: {
+      topLeft: '',
+      bottomRight: '',
+    },
+
+    fontSize: {
+      xs: 'text-xs',
+      sm: 'text-sm',
+      base: 'text-base',
+      xl: 'text-xl',
+      '2xl': 'text-2xl',
+    },
+  },
+});
+
+type DropdownSizeType = 'wh24' | 'wh36';
+
+const getDropdownSize = (size: DropdownSizeType | undefined) => {
+  switch (size) {
+    case 'wh24':
+      return { width: 24, height: 24 };
+    case 'wh36':
+      return { width: 36, height: 36 };
+    default:
+      return { width: 24, height: 24 };
+  }
+};
+
+interface TextCardProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof textCardVariants> {
+  isDropdown?: boolean;
+  cardContent?: string;
+  author?: string;
+  tags?: string[];
+  maxTags?: number; // 최대 표시할 태그 수
+  dropdownSize?: DropdownSizeType;
+}
+
+export default function TextCard({ isDropdown, cardContent, author, tags = [], maxTags = 2, variant, width, fixedSize, fontSize, tagPosition, dropdownSize, className, ...props }: TextCardProps) {
+  let fixedSizeClass = '';
+  if (fixedSize === 'w294h180') fixedSizeClass = 'w-[294px] h-[180px]';
+  else if (fixedSize === 'w312h140') fixedSizeClass = 'w-[312px] h-[140px]';
+  else if (fixedSize === 'w585h259') fixedSizeClass = 'w-[585px] h-[259px]';
+
+  const displayTags = tags.length > maxTags ? [...tags.slice(0, maxTags), '...'] : tags;
+
+  // 드롭다운 아이콘 사이즈
+  const iconSize = getDropdownSize(dropdownSize);
+
+  if (fixedSize) {
+    return (
+      <div
+        className={`${textCardVariants({
+          variant,
+          width,
+          fontSize,
+          tagPosition,
+          className,
+        })} relative mx-auto`}
+        {...props}
+      >
+        <div className={`${fixedSizeClass} relative`}>
+          <div className='p-[22px]'>
+            <div className='line-clamp-4'>{cardContent}</div>
+
+            {author && <div className='absolute right-5 bottom-5 text-blue-400'>- {author} -</div>}
+          </div>
+          {isDropdown && (
+            <div className='absolute top-4 right-4 cursor-pointer'>
+              <Image src={dropdown_icon} alt='드롭다운 메뉴 아이콘' width={iconSize.width} height={iconSize.height} />
+            </div>
+          )}
+        </div>
+        {tags.length > 0 && (
+          <div
+            className={`${tagPosition === 'topLeft' ? 'absolute left-0' : 'absolute right-0 text-right'} flex flex-row flex-wrap text-blue-400`}
+            style={{
+              top: tagPosition === 'topLeft' ? `calc(-1.5em - 12px)` : undefined,
+              bottom: tagPosition === 'bottomRight' ? `calc(-1.5em - 12px)` : undefined,
+            }}
+          >
+            {displayTags.map((tag, index) => (
+              <span key={index} className='px-2 py-1 text-blue-400'>
+                {tag === '...' ? tag : `#${tag}`}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${textCardVariants({
+        variant,
+        width,
+        fixedSize,
+        fontSize,
+        tagPosition,
+        className,
+      })} relative mx-auto`}
+      {...props}
+    >
+      <div>
+        <div className='p-[22px]'>
+          <div className='mb-4'>{cardContent}</div>
+
+          {author && <div className='text-right text-blue-400'>- {author} -</div>}
+        </div>
+        {isDropdown && (
+          <div className='absolute top-4 right-4 cursor-pointer'>
+            <Image src={dropdown_icon} alt='드롭다운 메뉴 아이콘' width={iconSize.width} height={iconSize.height} />
+          </div>
+        )}
+      </div>
+      {tags.length > 0 && (
+        <div
+          className={`${tagPosition === 'topLeft' ? 'absolute left-0' : 'absolute right-0 text-right'} text-blue-400`}
+          style={{
+            top: tagPosition === 'topLeft' ? `calc(-1.5em - 12px)` : undefined,
+            bottom: tagPosition === 'bottomRight' ? `calc(-1.5em - 12px)` : undefined,
+          }}
+        >
+          {displayTags.map((tag, index) => (
+            <span key={index} className='px-2 py-1 text-blue-400'>
+              {tag === '...' ? tag : `#${tag}`}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/textcard/index.tsx
+++ b/src/components/ui/textcard/index.tsx
@@ -1,8 +1,7 @@
 import { cva, VariantProps } from 'class-variance-authority';
 import { HTMLAttributes } from 'react';
 import { Iropke } from '@/fonts';
-import dropdown_icon from '@/assets/icons/dropdown_icon.svg';
-import Image from 'next/image';
+import DropdownMenu from '../DropdownMenu';
 
 const textCardVariants = cva(`border border-line-100 border-solid rounded-xl font-normal ${Iropke.className}`, {
   variants: {
@@ -45,38 +44,21 @@ const textCardVariants = cva(`border border-line-100 border-solid rounded-xl fon
   },
 });
 
-type DropdownSizeType = 'wh24' | 'wh36';
-
-const getDropdownSize = (size: DropdownSizeType | undefined) => {
-  switch (size) {
-    case 'wh24':
-      return { width: 24, height: 24 };
-    case 'wh36':
-      return { width: 36, height: 36 };
-    default:
-      return { width: 24, height: 24 };
-  }
-};
-
 interface TextCardProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof textCardVariants> {
   isDropdown?: boolean;
   cardContent?: string;
   author?: string;
   tags?: string[];
   maxTags?: number; // 최대 표시할 태그 수
-  dropdownSize?: DropdownSizeType;
 }
 
-export default function TextCard({ isDropdown, cardContent, author, tags = [], maxTags = 2, variant, width, fixedSize, fontSize, tagPosition, dropdownSize, className, ...props }: TextCardProps) {
+export default function TextCard({ isDropdown, cardContent, author, tags = [], maxTags = 2, variant, width, fixedSize, fontSize, tagPosition, className, ...props }: TextCardProps) {
   let fixedSizeClass = '';
   if (fixedSize === 'w294h180') fixedSizeClass = 'w-[294px] h-[180px]';
   else if (fixedSize === 'w312h140') fixedSizeClass = 'w-[312px] h-[140px]';
   else if (fixedSize === 'w585h259') fixedSizeClass = 'w-[585px] h-[259px]';
 
   const displayTags = tags.length > maxTags ? [...tags.slice(0, maxTags), '...'] : tags;
-
-  // 드롭다운 아이콘 사이즈
-  const iconSize = getDropdownSize(dropdownSize);
 
   if (fixedSize) {
     return (
@@ -97,8 +79,8 @@ export default function TextCard({ isDropdown, cardContent, author, tags = [], m
             {author && <div className='absolute right-5 bottom-5 text-blue-400'>- {author} -</div>}
           </div>
           {isDropdown && (
-            <div className='absolute top-4 right-4 cursor-pointer'>
-              <Image src={dropdown_icon} alt='드롭다운 메뉴 아이콘' width={iconSize.width} height={iconSize.height} />
+            <div className='absolute right-0' style={{ top: `calc(-1.5em - 12px)` }}>
+              <DropdownMenu />
             </div>
           )}
         </div>
@@ -140,8 +122,8 @@ export default function TextCard({ isDropdown, cardContent, author, tags = [], m
           {author && <div className='text-right text-blue-400'>- {author} -</div>}
         </div>
         {isDropdown && (
-          <div className='absolute top-4 right-4 cursor-pointer'>
-            <Image src={dropdown_icon} alt='드롭다운 메뉴 아이콘' width={iconSize.width} height={iconSize.height} />
+          <div className='absolute right-0' style={{ top: `calc(-1.5em - 12px)` }}>
+            <DropdownMenu />
           </div>
         )}
       </div>

--- a/src/stories/textCard/index.stories.tsx
+++ b/src/stories/textCard/index.stories.tsx
@@ -1,0 +1,160 @@
+import TextCard from '@/components/ui/textcard';
+import { Iropke } from '@/fonts';
+import { cn } from '@/utils/cn';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof TextCard> = {
+  title: 'TextCard/TextCard',
+  component: TextCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+
+  decorators: [
+    (Story) => (
+      <div className={cn('rounded-xl bg-white', Iropke.className)}>
+        <Story />
+      </div>
+    ),
+  ],
+
+  argTypes: {
+    variant: {
+      options: ['fixedHeight', 'variantHeight'],
+      control: { type: 'select' },
+    },
+
+    width: {
+      options: ['w286', 'w294', 'w312', 'w366', 'w384', 'w472', 'w540', 'w585', 'w640', 'w744'],
+      control: { type: 'select' },
+    },
+
+    fixedSize: {
+      options: ['w294h214', 'w312h172', 'w585h307'],
+      control: { type: 'select' },
+    },
+
+    tagPosition: {
+      options: ['topLeft', 'bottomRight'],
+      control: { type: 'select' },
+    },
+
+    fontSize: {
+      options: ['xs', 'sm', 'base', 'xl', '2xl'],
+      control: { type: 'select' },
+    },
+  },
+};
+
+type Story = StoryObj<typeof TextCard>;
+
+export default meta;
+
+export const variableDefault: Story = {
+  args: {
+    variant: 'variableHeight',
+    width: 'w286',
+    tagPosition: 'bottomRight',
+    fontSize: 'xs',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const variableW312: Story = {
+  args: {
+    variant: 'variableHeight',
+    width: 'w312',
+    tagPosition: 'bottomRight',
+    fontSize: 'sm',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const variableW384: Story = {
+  args: {
+    variant: 'variableHeight',
+    width: 'w384',
+    tagPosition: 'bottomRight',
+    fontSize: 'base',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const variableW540: Story = {
+  args: {
+    variant: 'variableHeight',
+    width: 'w540',
+    tagPosition: 'bottomRight',
+    fontSize: 'xl',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const variableW640: Story = {
+  args: {
+    variant: 'variableHeight',
+    width: 'w640',
+    tagPosition: 'bottomRight',
+    fontSize: 'xl',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const variableW744: Story = {
+  args: {
+    variant: 'variableHeight',
+    width: 'w744',
+    tagPosition: 'bottomRight',
+    fontSize: '2xl',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const fixedW294: Story = {
+  args: {
+    variant: 'fixedHeight',
+    fixedSize: 'w294h180',
+    tagPosition: 'bottomRight',
+    fontSize: 'base',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const fixedW312: Story = {
+  args: {
+    variant: 'fixedHeight',
+    fixedSize: 'w312h140',
+    tagPosition: 'bottomRight',
+    fontSize: 'sm',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};
+
+export const fixedW585: Story = {
+  args: {
+    variant: 'fixedHeight',
+    fixedSize: 'w585h259',
+    tagPosition: 'bottomRight',
+    fontSize: '2xl',
+    tags: ['태그내용', '나는 태그입니다'],
+    cardContent: '여기에 카드 내용이 들어갑니다.',
+    author: '저자 이름',
+  },
+};

--- a/src/stories/textarea/index.stories.tsx
+++ b/src/stories/textarea/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { cn } from '@/utils/cn';
-import TextArea from '@/components/ui/textarea';
+import TextArea, { TextAreaProps } from '@/components/ui/textarea';
 import { Pretendard } from '@/fonts';
 
 const meta: Meta<typeof TextArea> = {
@@ -43,9 +43,15 @@ const meta: Meta<typeof TextArea> = {
   },
 };
 
-export default meta;
-
 type Story = StoryObj<typeof TextArea>;
+
+const render = (args: TextAreaProps) => {
+  const placeholder = args.variant === 'limit100' ? '100자 이내로 입력해주세요' : '500자 이내로 입력해주세요';
+
+  return <TextArea {...args} placeholder={placeholder} />;
+};
+
+export default meta;
 
 export const Small100: Story = {
   args: {
@@ -56,6 +62,7 @@ export const Small100: Story = {
     borderRadius: 'lg',
     placeholder: '100자 이내로 입력해주세요.',
   },
+  render,
 };
 
 export const Medium100: Story = {
@@ -67,6 +74,7 @@ export const Medium100: Story = {
     borderRadius: 'lg',
     placeholder: '100자 이내로 입력해주세요.',
   },
+  render,
 };
 
 export const Large100: Story = {
@@ -78,6 +86,7 @@ export const Large100: Story = {
     borderRadius: 'lg',
     placeholder: '100자 이내로 입력해주세요.',
   },
+  render,
 };
 
 export const Small500: Story = {
@@ -89,6 +98,7 @@ export const Small500: Story = {
     borderRadius: 'xl',
     placeholder: '500자 이내로 입력해주세요.',
   },
+  render,
 };
 
 export const Medium500: Story = {
@@ -100,6 +110,7 @@ export const Medium500: Story = {
     borderRadius: 'xl',
     placeholder: '500자 이내로 입력해주세요.',
   },
+  render,
 };
 
 export const Large500: Story = {
@@ -111,4 +122,5 @@ export const Large500: Story = {
     borderRadius: 'xl',
     placeholder: '500자 이내로 입력해주세요.',
   },
+  render,
 };


### PR DESCRIPTION
## ❓이슈
- close #16 

## :writing_hand: Description

text card 컴포넌트 구현에 관한 PR 입니다. 

우선 미흡한 점이 2가지가 있는데 
1. 새벽작업 하다보니 dropdownmenu 컴포넌트가 있는데, 이걸로 안넣고 이미지만 넣어놨습니다. 추후 수정하겠습니다. -> 해결
2. text card 중에 태그가 세로로 배치된 게 있는데, 태그를 세로로 배치하다가 버그가 너무 많이 나서 개발을 했다가 지웠습니다. 저게 모바일화면에서 태그가 세로로 배치된 걸 쓸건지, 가로로 배치된 걸 쓸건지 정해야 하는 것 같은데, 세로로 된 걸 쓰면 추후 개발하도록 하겠습니다.

주요기능
1. 원래는 문구의 내용이 길수록  text card 크기가 커지는데, 고정된 크기의 text card도 필요하여 variant는 fixedHeight와 variableHeight 두가지입니다.
2. 에피그램_상세페이지에서 태그가 왼쪽위에 있는 것도 있어서 태그위치도 받게 했습니다.

아래는 storybook 발췌 사진입니다.

태그의 갯수가 2개가 넘어가면 ...으로 표시되게 했습니다.
![image](https://github.com/user-attachments/assets/341affb1-c48d-4bc9-b9d5-2be50a4f3f2b)

마찬가지로, 안의 내용물이 4줄이 넘어가면 ...으로 표시되게 했습니다. (fixedHeight, 즉 고정된 text card 에서만 입니다.)
![image](https://github.com/user-attachments/assets/d39d0d9c-1598-4f4a-a214-261584ffb621)





## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
