### PR TITLE
EP-48 로그인 페이지 구현

### DIFF
--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('로그인 페이지', () => {
+  test('로그인 페이지 로드 확인', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page).toHaveURL('http://localhost:3000/login');
+  });
+
+  test('로고 클릭 시 랜딩페이지로 이동한다.', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByAltText('로고').click();
+    await expect(page).toHaveURL('http://localhost:3000');
+  });
+
+  test('가입하기 텍스트 클릭 시 로그인 페이지로 이동한다.', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('link', { name: '가입하기' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/signup');
+  });
+
+  test('가입되지 않은 이메일로 로그인을 시도하면, alert 모달이 렌더링된다.', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('email-input-login').fill('testFFFFFF@email.com');
+    await page.getByTestId('password-input-login').fill('password1!');
+    await page.getByRole('button', { name: '로그인' }).click();
+
+    await expect(page.getByText('존재하지 않는 이메일입니다.')).toBeVisible();
+    await page.getByRole('button', { name: '확인' }).click();
+    await expect(page.getByText('존재하지 않는 이메일입니다.')).toBeHidden();
+  });
+
+  test('일치하지 않는 비밀번호로 로그인을 시도하면, alert 모달이 렌더링된다.', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('email-input-login').fill('test5@email.com');
+    await page.getByTestId('password-input-login').fill('password');
+    await page.getByRole('button', { name: '로그인' }).click();
+
+    await expect(page.getByText('비밀번호가 일치하지 않습니다.')).toBeVisible();
+    await page.getByRole('button', { name: '확인' }).click();
+    await expect(page.getByText('비밀번호가 일치하지 않습니다.')).toBeHidden();
+  });
+
+  test('카카오 로그인 실패 시 쿼리 스트링과 함께 로그인 페이지로 리다이렉트 되며, alert 모달이 렌더링된다.', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByAltText('카카오 소셜 로그인').click();
+
+    expect(page.url()).toContain('accounts.kakao.com/login');
+
+    await page.goto('/oauth/signup/kakao?error=access-denied');
+    await expect(page).toHaveURL(/\/login\?error=/);
+
+    const url = new URL(page.url());
+    const errorMessage = url.searchParams.get('error') ?? '';
+    await expect(page.getByText(errorMessage)).toBeVisible();
+  });
+
+  test('구글 로그인 실패 시 쿼리 스트링과 함께 로그인 페이지로 리다이렉트 되며, alert 모달이 렌더링된다.', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByAltText('구글 소셜 로그인').click();
+
+    expect(page.url()).toContain('accounts.google.com');
+
+    await page.goto('/oauth/signup/google?error=access-denied');
+    await expect(page).toHaveURL(/\/login\?error=/);
+
+    const url = new URL(page.url());
+    const errorMessage = url.searchParams.get('error') ?? '';
+    await expect(page.getByText(errorMessage)).toBeVisible();
+  });
+
+  test('카카오 로그인에 성공하면 랜딩페이지로 리다이렉트 된다.', async ({ page }) => {
+    await page.route('**/oauth/signup/kakao**', (route) => {
+      route.fulfill({
+        status: 307,
+        headers: {
+          'set-cookie': 'accessToken=testHeader.testPayload.testSignature; Path=/; HttpOnly; Same-Site=Lax, refreshToken=testHeader.testPayload.testSignature; Path=/; HttpOnly; Same-Site=Lax',
+          location: 'http://localhost:3000',
+        },
+      });
+    });
+
+    await page.goto('/login');
+
+    await page.evaluate(() => {
+      const img = document.querySelector('img[alt="카카오 소셜 로그인"]') as HTMLImageElement;
+
+      img.onclick = async (event) => {
+        event.stopPropagation();
+        await fetch('/oauth/signup/kakao?code=success-code');
+        window.location.href = 'http://localhost:3000';
+      };
+    });
+    await page.click('img[alt="카카오 소셜 로그인"]');
+    await expect(page).toHaveURL('http://localhost:3000');
+  });
+
+  test('구글 로그인에 성공하면 랜딩페이지로 리다이렉트 된다.', async ({ page }) => {
+    await page.route('**/oauth/signup/google**', (route) => {
+      route.fulfill({
+        status: 307,
+        headers: {
+          'set-cookie': 'accessToken=testHeader.testPayload.testSignature; Path=/; HttpOnly; Same-Site=Lax, refreshToken=testHeader.testPayload.testSignature; Path=/; HttpOnly; Same-Site=Lax',
+          location: 'http://localhost:3000',
+        },
+      });
+    });
+
+    await page.goto('/login');
+
+    await page.evaluate(() => {
+      const img = document.querySelector('img[alt="구글 소셜 로그인"]') as HTMLImageElement;
+
+      img.onclick = async (event) => {
+        event.stopPropagation();
+        await fetch('/oauth/signup/google?code=success-code');
+        window.location.href = 'http://localhost:3000';
+      };
+    });
+    await page.click('img[alt="구글 소셜 로그인"]');
+    await expect(page).toHaveURL('http://localhost:3000');
+  });
+
+  test('로그인이 되어있으면, 랜딩 페이지로 리다이렉트 된다.', async ({ browser }) => {
+    const context = await browser.newContext();
+    await context.addCookies([
+      {
+        name: 'accessToken',
+        value: 'testHeader.testPayload,testSignature',
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+        secure: false,
+        sameSite: 'Lax',
+      },
+      {
+        name: 'refreshToken',
+        value: 'testHeader.testPayload,testSignature',
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+        secure: false,
+        sameSite: 'Lax',
+      },
+    ]);
+
+    const loggedInPage = await context.newPage();
+    await loggedInPage.goto('/login');
+    await expect(loggedInPage).toHaveURL('http://localhost:3000');
+    await context.close();
+  });
+
+  test('로그인에 성공하면 로그인 성공 메시지를 표시하며, 확인 버튼을 누르면 랜딩페이지로 이동한다.', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('email-input-login').fill('test5@email.com');
+    await page.getByTestId('password-input-login').fill('password1!');
+    await page.getByRole('button', { name: '로그인' }).click();
+
+    await expect(page.getByText('로그인에 성공했습니다!')).toBeVisible();
+    await page.getByRole('button', { name: '확인' }).click();
+    await expect(page.getByText('로그인에 성공했습니다!')).toBeHidden();
+  });
+});

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -12,6 +12,12 @@ test.describe('회원가입 페이지', () => {
     await expect(page).toHaveURL('http://localhost:3000');
   });
 
+  test('로그인하기 텍스트 클릭 시 로그인 페이지로 이동한다.', async ({ page }) => {
+    await page.goto('/signup');
+    await page.getByRole('link', { name: '로그인하기' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/login');
+  });
+
   test('중복된 이메일을 제출하면, alert 창으로 메시지를 표시하며, 확인 버튼을 누르면 모달이 닫힌다.', async ({ page }) => {
     await page.goto('/signup');
     await page.getByTestId('email-input').fill('test@email.com');

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,7 +1,7 @@
 import axiosClientHelper from '@/utils/network/axiosClientHelper';
 import { safeResponse } from '@/utils/network/safeResponse';
 import { userResponseSchema } from '@/schemas';
-import { SignupForm, User } from '@/types';
+import { LoginForm, SignupForm, User } from '@/types';
 
 /**
  * 회원가입
@@ -9,5 +9,14 @@ import { SignupForm, User } from '@/types';
  */
 export const signup = async (signupForm: SignupForm) => {
   const response = await axiosClientHelper.post<{ user: User }>('/auth/signUp', signupForm);
+  return safeResponse(response.data, userResponseSchema);
+};
+
+/**
+ * 로그인
+ * https://fe-project-epigram-api.vercel.app/docs/#/Auth/SignIn
+ */
+export const login = async (loginForm: LoginForm) => {
+  const response = await axiosClientHelper.post<{ user: User }>('/auth/signIn', loginForm);
   return safeResponse(response.data, userResponseSchema);
 };

--- a/src/apis/auth/queries.tsx
+++ b/src/apis/auth/queries.tsx
@@ -1,11 +1,19 @@
 import { useMutation } from '@tanstack/react-query';
-import { SignupForm } from '@/types';
-import { signup } from '.';
+import { LoginForm, SignupForm } from '@/types';
+import { login, signup } from '.';
 
 export const useSignup = () => {
   return useMutation({
     mutationFn: (signupForm: SignupForm) => {
       return signup(signupForm);
+    },
+  });
+};
+
+export const useLogin = () => {
+  return useMutation({
+    mutationFn: (loginForm: LoginForm) => {
+      return login(loginForm);
     },
   });
 };

--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from 'react';
+
+export default function LoginLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <Suspense>{children}</Suspense>;
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -12,7 +12,7 @@ export default function Login() {
           가입하기
         </Link>
       </span>
-      <SocialButtonGroup />
+      <SocialButtonGroup endPoint='/login' />
     </div>
   );
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,8 +1,31 @@
+'use client';
+
 import LoginForm from '@/components/auth/LoginForm';
 import SocialButtonGroup from '@/components/auth/SocialButtonGroup';
+import { useModalStore } from '@/stores/ModalStore';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 export default function Login() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const errorMessage = searchParams.get('error');
+  const { openModal } = useModalStore();
+
+  useEffect(() => {
+    if (errorMessage) {
+      openModal({
+        type: 'alert',
+        title: '오류가 발생했습니다.',
+        description: errorMessage,
+        callback: () => {
+          router.replace('/login');
+        },
+      });
+    }
+  }, [errorMessage, openModal, router]);
+
   return (
     <div className='flex w-full flex-col items-center justify-center gap-2 px-4'>
       <LoginForm />

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,10 +1,17 @@
 import LoginForm from '@/components/auth/LoginForm';
 import SocialButtonGroup from '@/components/auth/SocialButtonGroup';
+import Link from 'next/link';
 
 export default function Login() {
   return (
     <div className='flex w-full flex-col items-center justify-center gap-2 px-4'>
       <LoginForm />
+      <span className='text-xs text-blue-400'>
+        회원이 아니신가요?{' '}
+        <Link href='/signup' className='text-black-500 underline'>
+          가입하기
+        </Link>
+      </span>
       <SocialButtonGroup />
     </div>
   );

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,3 +1,11 @@
+import LoginForm from '@/components/auth/LoginForm';
+import SocialButtonGroup from '@/components/auth/SocialButtonGroup';
+
 export default function Login() {
-  return <div>로그인 페이지</div>;
+  return (
+    <div className='flex w-full flex-col items-center justify-center gap-2 px-4'>
+      <LoginForm />
+      <SocialButtonGroup />
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,3 @@
-'use client';
-
-import { useGetUser } from '@/apis/user/queries';
-
 export default function Home() {
-  const { data } = useGetUser();
-  return <div>landing Page {JSON.stringify(data)}</div>;
+  return <div>landing Page</div>;
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,0 +1,3 @@
+export default function LoginForm() {
+  return <form></form>;
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -4,11 +4,15 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema } from '@/schemas';
 import { LoginForm as LoginFormType } from '@/types';
 import Input from '@/components/ui/Field/Input';
 import Button from '@/components/ui/buttons';
+import { useModalStore } from '@/stores/ModalStore';
+import { getErrorMessage } from '@/utils/network/getErrorMessage';
+import { useLogin } from '@/apis/auth/queries';
 import OpendEye from '@/assets/icons/opend_eye.svg';
 import ClosedEye from '@/assets/icons/closed_eye.svg';
 import Logo from '@/assets/images/logo.png';
@@ -16,6 +20,8 @@ import Logo from '@/assets/images/logo.png';
 export default function LoginForm() {
   const {
     register,
+    handleSubmit,
+    reset,
     formState: { errors, isDirty, isValid, isSubmitting },
   } = useForm<LoginFormType>({
     resolver: zodResolver(loginSchema),
@@ -26,11 +32,37 @@ export default function LoginForm() {
     },
   });
 
+  const { mutateAsync: login } = useLogin();
+  const { openModal } = useModalStore();
+  const router = useRouter();
+
   const [isShowPassword, setIsShowPassword] = useState(true);
   const isDisabled = !isDirty || !isValid || isSubmitting;
 
+  const onSubmit = async (loginForm: LoginFormType) => {
+    try {
+      await login(loginForm);
+      reset();
+      openModal({
+        type: 'alert',
+        title: '로그인에 성공했습니다!',
+        description: '확인 버튼을 누르시면 홈페이지로 이동합니다.',
+        callback: () => {
+          router.push('/');
+        },
+      });
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      openModal({
+        type: 'alert',
+        title: '회원가입에 실패했습니다.',
+        description: errorMessage,
+      });
+    }
+  };
+
   return (
-    <form className='flex w-full max-w-96 flex-col gap-2'>
+    <form className='flex w-full max-w-96 flex-col gap-2' onSubmit={handleSubmit(onSubmit)}>
       <Link className='flex w-full items-center justify-center' href='/'>
         <Image src={Logo} alt='로고' width={172} height={48} className='cursor-pointer' />
       </Link>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -5,13 +5,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema } from '@/schemas';
 import { LoginForm as LoginFormType } from '@/types';
 import Input from '@/components/ui/Field/Input';
+import Button from '@/components/ui/buttons';
 import OpendEye from '@/assets/icons/opend_eye.svg';
 import ClosedEye from '@/assets/icons/closed_eye.svg';
 
 export default function LoginForm() {
   const {
     register,
-    formState: { errors },
+    formState: { errors, isDirty, isValid, isSubmitting },
   } = useForm<LoginFormType>({
     resolver: zodResolver(loginSchema),
     mode: 'onBlur',
@@ -20,7 +21,10 @@ export default function LoginForm() {
       password: '',
     },
   });
+
   const [isShowPassword, setIsShowPassword] = useState(true);
+  const isDisabled = !isDirty || !isValid || isSubmitting;
+
   return (
     <form>
       <Input label='이메일' error={errors.email?.message} type='email' placeholder='이메일' required {...register('email')} data-testid='email-input-login' />
@@ -44,6 +48,9 @@ export default function LoginForm() {
           data-testid='password-toggle-login'
         />
       </div>
+      <Button disabled={isDisabled} className='w-full' data-testid='login-button'>
+        로그인
+      </Button>
     </form>
   );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -13,11 +13,13 @@ export default function LoginForm() {
     mode: 'onBlur',
     defaultValues: {
       email: '',
+      password: '',
     },
   });
   return (
     <form>
       <Input label='이메일' error={errors.email?.message} type='email' placeholder='이메일' required {...register('email')} data-testid='email-input-login' />
+      <Input label='비밀번호' error={errors.password?.message} type='password' placeholder='비밀번호' required {...register('password')} data-testid='password-input-login' />
     </form>
   );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,8 +1,12 @@
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import Image from 'next/image';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema } from '@/schemas';
 import { LoginForm as LoginFormType } from '@/types';
 import Input from '@/components/ui/Field/Input';
+import OpendEye from '@/assets/icons/opend_eye.svg';
+import ClosedEye from '@/assets/icons/closed_eye.svg';
 
 export default function LoginForm() {
   const {
@@ -16,10 +20,30 @@ export default function LoginForm() {
       password: '',
     },
   });
+  const [isShowPassword, setIsShowPassword] = useState(true);
   return (
     <form>
       <Input label='이메일' error={errors.email?.message} type='email' placeholder='이메일' required {...register('email')} data-testid='email-input-login' />
-      <Input label='비밀번호' error={errors.password?.message} type='password' placeholder='비밀번호' required {...register('password')} data-testid='password-input-login' />
+      <div className='relative'>
+        <Input
+          label='비밀번호'
+          type={isShowPassword ? 'password' : 'text'}
+          error={errors.password?.message}
+          placeholder='비밀번호'
+          required
+          {...register('password')}
+          data-testid='password-input-login'
+        />
+        <Image
+          src={isShowPassword ? ClosedEye : OpendEye}
+          alt='비밀번호 토글 이미지'
+          width={24}
+          height={24}
+          className='absolute top-[46px] right-3 cursor-pointer lg:top-[60px]'
+          onClick={() => setIsShowPassword((prev) => !prev)}
+          data-testid='password-toggle-login'
+        />
+      </div>
     </form>
   );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,3 +1,23 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { loginSchema } from '@/schemas';
+import { LoginForm as LoginFormType } from '@/types';
+import Input from '@/components/ui/Field/Input';
+
 export default function LoginForm() {
-  return <form></form>;
+  const {
+    register,
+    formState: { errors },
+  } = useForm<LoginFormType>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      email: '',
+    },
+  });
+  return (
+    <form>
+      <Input label='이메일' error={errors.email?.message} type='email' placeholder='이메일' required {...register('email')} data-testid='email-input-login' />
+    </form>
+  );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -99,7 +99,7 @@ export default function LoginForm() {
           data-testid='password-toggle-login'
         />
       </div>
-      <Button disabled={isDisabled} className='w-full' data-testid='login-button'>
+      <Button disabled={isDisabled} className='text-md w-full' data-testid='login-button' size='xs'>
         로그인
       </Button>
     </form>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Image from 'next/image';
+import Link from 'next/link';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema } from '@/schemas';
 import { LoginForm as LoginFormType } from '@/types';
@@ -8,6 +11,7 @@ import Input from '@/components/ui/Field/Input';
 import Button from '@/components/ui/buttons';
 import OpendEye from '@/assets/icons/opend_eye.svg';
 import ClosedEye from '@/assets/icons/closed_eye.svg';
+import Logo from '@/assets/images/logo.png';
 
 export default function LoginForm() {
   const {
@@ -26,8 +30,21 @@ export default function LoginForm() {
   const isDisabled = !isDirty || !isValid || isSubmitting;
 
   return (
-    <form>
-      <Input label='이메일' error={errors.email?.message} type='email' placeholder='이메일' required {...register('email')} data-testid='email-input-login' />
+    <form className='flex w-full max-w-96 flex-col gap-2'>
+      <Link className='flex w-full items-center justify-center' href='/'>
+        <Image src={Logo} alt='로고' width={172} height={48} className='cursor-pointer' />
+      </Link>
+      <Input
+        label='이메일'
+        error={errors.email?.message}
+        type='email'
+        placeholder='이메일'
+        required
+        {...register('email')}
+        data-testid='email-input-login'
+        disabled={isSubmitting}
+        className='text-md md:text-lg lg:text-xl'
+      />
       <div className='relative'>
         <Input
           label='비밀번호'
@@ -37,6 +54,8 @@ export default function LoginForm() {
           required
           {...register('password')}
           data-testid='password-input-login'
+          disabled={isSubmitting}
+          className='text-md md:text-lg lg:text-xl'
         />
         <Image
           src={isShowPassword ? ClosedEye : OpendEye}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -40,3 +40,7 @@ export const userSchema = z.object({
 export const userResponseSchema = z.object({
   user: userSchema,
 });
+
+export const loginSchema = z.object({
+  email: z.string().min(1, '이메일은 필수 입력입니다.'),
+});

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -43,4 +43,5 @@ export const userResponseSchema = z.object({
 
 export const loginSchema = z.object({
   email: z.string().min(1, '이메일은 필수 입력입니다.').email('이메일 형식으로 작성해 주세요.'),
+  password: z.string().min(1, '비밀번호는 필수 입력입니다.'),
 });

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -42,5 +42,5 @@ export const userResponseSchema = z.object({
 });
 
 export const loginSchema = z.object({
-  email: z.string().min(1, '이메일은 필수 입력입니다.'),
+  email: z.string().min(1, '이메일은 필수 입력입니다.').email('이메일 형식으로 작성해 주세요.'),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
-import { signupSchema, userSchema } from '@/schemas';
+import { loginSchema, signupSchema, userSchema } from '@/schemas';
 
 export type SignupForm = z.infer<typeof signupSchema>;
 
 export type User = z.infer<typeof userSchema>;
+
+export type LoginForm = z.infer<typeof loginSchema>;

--- a/tests/LoginForm.test.tsx
+++ b/tests/LoginForm.test.tsx
@@ -37,6 +37,20 @@ describe('LoginForm', () => {
     expect(await screen.findByText('비밀번호는 필수 입력입니다.')).toBeInTheDocument();
   });
 
+  test('비밀번호 토글 버튼을 누르면 password의 타입이 text로 변한다', async () => {
+    renderWithQueryClient(<LoginForm />);
+
+    const passwordInput = screen.getByTestId('password-input-login');
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    const passwordToggle = screen.getByTestId('password-toggle-login');
+    await userEvent.click(passwordToggle);
+    expect(passwordInput).toHaveAttribute('type', 'text');
+
+    await userEvent.click(passwordToggle);
+    expect(passwordInput).toHaveAttribute('type', 'password');
+  });
+
   test('모든 유효성 검사가 통과하면 제출 버튼이 활성화된다', async () => {
     renderWithQueryClient(<LoginForm />);
 

--- a/tests/LoginForm.test.tsx
+++ b/tests/LoginForm.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginForm from '@/components/auth/LoginForm';
+import QueryClientProvider from '@/apis/QueryProvider';
+import { ReactNode } from 'react';
+
+const renderWithQueryClient = (ui: ReactNode) => {
+  return render(<QueryClientProvider>{ui}</QueryClientProvider>);
+};
+
+describe('LoginForm', () => {
+  test('이메일 필드가 비어있을 때 blur 시 필수 입력 오류 메시지를 표시한다', async () => {
+    renderWithQueryClient(<LoginForm />);
+    const emailInput = screen.getByTestId('email-input-login');
+    fireEvent.focus(emailInput);
+    fireEvent.blur(emailInput);
+
+    expect(await screen.findByText('이메일은 필수 입력입니다.')).toBeInTheDocument();
+  });
+
+  test('이메일 형식이 아닌 상태에서 blur 시 형식 오류 메시지를 표시한다', async () => {
+    renderWithQueryClient(<LoginForm />);
+    const emailInput = screen.getByTestId('email-input-login');
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } });
+    fireEvent.blur(emailInput);
+
+    expect(await screen.findByText('이메일 형식으로 작성해 주세요.')).toBeInTheDocument();
+  });
+
+  test('비밀번호 필드가 비어있을 때 blur 시 필수 입력 오류 메시지를 표시한다', async () => {
+    renderWithQueryClient(<LoginForm />);
+
+    const passwordInput = screen.getByTestId('password-input-login');
+    fireEvent.focus(passwordInput);
+    fireEvent.blur(passwordInput);
+
+    expect(await screen.findByText('비밀번호는 필수 입력입니다.')).toBeInTheDocument();
+  });
+
+  test('모든 유효성 검사가 통과하면 제출 버튼이 활성화된다', async () => {
+    renderWithQueryClient(<LoginForm />);
+
+    const submitButton = screen.getByTestId('login-button');
+    expect(submitButton).toBeDisabled();
+
+    const emailInput = screen.getByTestId('email-input-login');
+    const passwordInput = screen.getByTestId('password-input-login');
+
+    await userEvent.type(emailInput, 'valid@example.com');
+    await userEvent.type(passwordInput, 'Password123!');
+
+    fireEvent.blur(emailInput);
+    fireEvent.blur(passwordInput);
+
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+});


### PR DESCRIPTION
## ❓이슈
- close #55 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

로그인 페이지 구현에 관한 PR입니다.

작업한 내용은 다음과 같습니다.

1. 로그인 폼 구현
2. 로그인 페이지 searchParams error 값에 따른 alert 표시
3. 로그인 폼 통합 테스트
4. 로그인 페이지 E2E 테스트

E2E 테스트 시나리오는 다음과 같습니다.

[실패 시나리오]
1. 가입되지 않은 이메일로 로그인 시 alert 모달 렌더링
2. 일치하지 않은 비밀번호로 로그인 시 alert 모달 렌더링
3. 소셜 로그인 실패 시 로그인 페이지 리다이렉트 및 오류 메시지 표시

[성공 시나리오]
1. 소셜 로그인 성공 시 랜딩페이지로 리다이렉트 됨.
2. 로그인 상태인 경우 랜딩페이지로 리다이렉트 됨.
3. 로그인에 성공하면 로그인 성공 메시지를 표시함.

[기타 시나리오]
1. 페이지 로드 확인
2. 로고 클릭 시 랜딩페이지로 이동됨.
3. 가입하기 텍스트 클릭 시 로그인 페이지로 이동됨.


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
