### PR TITLE
EP-66 redirect prefetch 동작 오류

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema } from '@/apis/auth/schemas';
 import { LoginForm as LoginFormType } from '@/apis/auth/types';
@@ -34,7 +33,6 @@ export default function LoginForm() {
 
   const { mutateAsync: login } = useLogin();
   const { openModal } = useModalStore();
-  const router = useRouter();
 
   const [isShowPassword, setIsShowPassword] = useState(true);
   const isDisabled = !isDirty || !isValid || isSubmitting;
@@ -48,7 +46,7 @@ export default function LoginForm() {
         title: '로그인에 성공했습니다!',
         description: '확인 버튼을 누르시면 홈페이지로 이동합니다.',
         callback: () => {
-          router.push('/');
+          window.location.href = '/';
         },
       });
     } catch (error) {

--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -19,7 +19,7 @@ export default function LogoutButton({ className }: { className?: string }) {
         type: 'alert',
         title: '로그아웃이 완료되었습니다.',
         callback: () => {
-          router.replace('/login');
+          window.location.href = '/login';
         },
       });
     } else {


### PR DESCRIPTION
## ❓이슈
- close #85 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

next에서 Link 컴포넌트는 프리페칭이 default 옵션으로 켜져있습니다.

이로 인해 로그인 후 홈페이지로 라우팅한 후 버튼을 통해 보호된 페이지로 이동하려할 경우 이미 로그인 페이지로 프리페칭되었기 때문에 헤더의 우측 아이콘을 클릭해도(로그인 된 상태) 마이페이지가 아닌 로그인 페이지로 가는 이슈가 있습니다.

이를 해결하기 위해 로그인 후 홈페이지로 이동하는 걸 라우트가 아닌 window location으로 변경하였고, 로그아웃 버튼도 마찬가지로 변경했습니다. 

NEXT 개발 모드에서는 프리페칭 동작을 확인할 수 없기 때문에 프리페칭 동작을 확인하려면 build 후 start하시면 되고,
프리페칭 된 증거로는 DevTools에서 rsc 페이로드를 보시면 됩니다.

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
