### PR TITLE
EP-51 수정 페이지 구현 

### DIFF
--- a/src/app/(after-login)/epigrams/[id]/edit/page.tsx
+++ b/src/app/(after-login)/epigrams/[id]/edit/page.tsx
@@ -1,3 +1,30 @@
+import Header from '@/components/ui/header/MainHeader';
+import Button from '@/components/ui/buttons/index';
+import { Pretendard } from '@/fonts';
+import Content from '@/components/edit/Content';
+import Author from '@/components/edit/Author';
+import Source from '@/components/edit/Source';
+import Tags from '@/components/edit/Tags';
+
+// 사실 한 페이지에서 구상을 하려고 했지만 가독성측면에서 분리를 하게됨
+// 1. 해당 페이지에서 가독성을 위해 컴포넌트를 나눔 2. 중복되는 부분이 많다고 판단함 쓸데없이 코드 길어짐 
 export default function EpigramEdit() {
-  return <div>에피그램 수정페이지</div>;
+  return (
+    <>
+      <Header></Header>
+      <div className='pt-14'>
+        <div className='mx-auto mt-[21px] flex h-196.25 w-78 flex-col gap-6 md:mt-9 md:h-202.75 md:w-[calc(100%-360px)] md:gap-8 xl:mt-20 xl:h-278.5 xl:w-160 xl:gap-10'>
+          <p className={`h-6.5 w-full md:h-8 ${Pretendard.className} text-lg font-semibold md:text-xl xl:text-2xl`}>에픽그램 수정</p>
+          <div className='bg-black-400 flex h-165.75 w-full flex-col gap-10 md:h-168.75 xl:h-234.5 xl:gap-13.5'>
+            <Content />
+            <Author />
+            <Source />
+            <Tags />
+          </div>
+          <Button className='bg-black-500 h-12 w-full xl:h-16'>수정 완료</Button>
+        </div>
+        ;
+      </div>
+    </>
+  );
 }

--- a/src/app/(after-login)/epigrams/[id]/edit/page.tsx
+++ b/src/app/(after-login)/epigrams/[id]/edit/page.tsx
@@ -1,14 +1,6 @@
-'use client';
-
-import { useForm } from 'react-hook-form';
 import Header from '@/components/ui/header/MainHeader';
-import Button from '@/components/ui/buttons/index';
 import { Pretendard } from '@/fonts';
-import Content from '@/components/edit/Content';
-import Author from '@/components/edit/Author';
-import Source from '@/components/edit/Source';
-import Tags from '@/components/edit/Tags';
-import { useState } from 'react';
+import EditForm from '@/components/edit/EditForm';
 
 // 목데이터로 임시 작업
 const mockData = {
@@ -18,47 +10,15 @@ const mockData = {
   tags: ['에픽그램', '수정', '예시'],
 };
 
-type FormData = { content: string };
-
 export default function EpigramEdit() {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    trigger,
-  } = useForm<{ content: string }>({ mode: 'onBlur' });
-
-  const [content, setContent] = useState(mockData.content);
-  const [author, setAuthor] = useState(mockData.author);
-  const [source, setSource] = useState(mockData.source);
-  const [tags, setTags] = useState(mockData.tags);
-
-  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setContent(e.target.value);
-  };
-
-  const onSubmit = (data: FormData) => {
-    console.log('제출된 데이터:', data);
-  };
-
   return (
     <>
       <Header />
       <div className='pt-14'>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <div className='mx-auto mt-[21px] flex h-196.25 w-78 flex-col gap-6 md:mt-9 md:h-202.75 md:w-[calc(100%-360px)] md:gap-8 xl:mt-20 xl:h-278.5 xl:w-160 xl:gap-10'>
-            <p className={`h-6.5 w-full md:h-8 ${Pretendard.className} text-lg font-semibold md:text-xl xl:text-2xl`}>에픽그램 수정</p>
-            <div className='flex h-165.75 w-full flex-col gap-10 md:h-168.75 xl:h-234.5 xl:gap-13.5'>
-              <Content content={content} onChange={handleContentChange} register={register} errors={errors} trigger={trigger} />
-              <Author author={author} onAuthorChange={setAuthor} />
-              <Source source={source} onSourceChange={setSource} />
-              <Tags tags={tags} onTagsChange={setTags} />
-            </div>
-            <Button type='submit' className='bg-black-500 h-12 w-full xl:h-16'>
-              수정 완료
-            </Button>
-          </div>
-        </form>
+        <div className='mx-auto mt-[21px] flex h-196.25 w-78 flex-col gap-6 md:mt-9 md:h-202.75 md:w-[calc(100%-360px)] md:gap-8 xl:mt-20 xl:h-278.5 xl:w-160 xl:gap-10'>
+          <p className={`h-6.5 w-full md:h-8 ${Pretendard.className} text-lg font-semibold md:text-xl xl:text-2xl`}>에픽그램 수정</p>
+          <EditForm initialData={mockData} />
+        </div>
       </div>
     </>
   );

--- a/src/app/(after-login)/epigrams/[id]/edit/page.tsx
+++ b/src/app/(after-login)/epigrams/[id]/edit/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useForm } from 'react-hook-form';
 import Header from '@/components/ui/header/MainHeader';
 import Button from '@/components/ui/buttons/index';
 import { Pretendard } from '@/fonts';
@@ -9,15 +10,24 @@ import Source from '@/components/edit/Source';
 import Tags from '@/components/edit/Tags';
 import { useState } from 'react';
 
-// 목데이터로 임시 작업했습니다. 추후 api 작업에서 변경하겠습니다. 
+// 목데이터로 임시 작업
 const mockData = {
-  content: '목데이터 용 내용입니다 .',
+  content: 'ㅁㄴㅇㄴㅁㅇㄴㅁㅇ',
   author: '정재형',
   source: '유튜브',
   tags: ['에픽그램', '수정', '예시'],
 };
 
+type FormData = { content: string };
+
 export default function EpigramEdit() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    trigger,
+  } = useForm<{ content: string }>({ mode: 'onBlur' });
+
   const [content, setContent] = useState(mockData.content);
   const [author, setAuthor] = useState(mockData.author);
   const [source, setSource] = useState(mockData.source);
@@ -27,32 +37,28 @@ export default function EpigramEdit() {
     setContent(e.target.value);
   };
 
-  const handleAuthorChange = (value: string) => {
-    setAuthor(value); 
-  };
-
-  const handleSourceChange = (value: string) => {
-    setSource(value); 
-  };
-
-  const handleTagsChange = (newTags: string[]) => {
-    setTags(newTags); 
+  const onSubmit = (data: FormData) => {
+    console.log('제출된 데이터:', data);
   };
 
   return (
     <>
       <Header />
       <div className='pt-14'>
-        <div className='mx-auto mt-[21px] flex h-196.25 w-78 flex-col gap-6 md:mt-9 md:h-202.75 md:w-[calc(100%-360px)] md:gap-8 xl:mt-20 xl:h-278.5 xl:w-160 xl:gap-10'>
-          <p className={`h-6.5 w-full md:h-8 ${Pretendard.className} text-lg font-semibold md:text-xl xl:text-2xl`}>에픽그램 수정</p>
-          <div className='flex h-165.75 w-full flex-col gap-10 md:h-168.75 xl:h-234.5 xl:gap-13.5'>
-            <Content content={content} onChange={handleContentChange} />
-            <Author author={author} onAuthorChange={handleAuthorChange} />
-            <Source source={source} onSourceChange={handleSourceChange} />
-            <Tags tags={tags} onTagsChange={handleTagsChange} />
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className='mx-auto mt-[21px] flex h-196.25 w-78 flex-col gap-6 md:mt-9 md:h-202.75 md:w-[calc(100%-360px)] md:gap-8 xl:mt-20 xl:h-278.5 xl:w-160 xl:gap-10'>
+            <p className={`h-6.5 w-full md:h-8 ${Pretendard.className} text-lg font-semibold md:text-xl xl:text-2xl`}>에픽그램 수정</p>
+            <div className='flex h-165.75 w-full flex-col gap-10 md:h-168.75 xl:h-234.5 xl:gap-13.5'>
+              <Content content={content} onChange={handleContentChange} register={register} errors={errors} trigger={trigger} />
+              <Author author={author} onAuthorChange={setAuthor} />
+              <Source source={source} onSourceChange={setSource} />
+              <Tags tags={tags} onTagsChange={setTags} />
+            </div>
+            <Button type='submit' className='bg-black-500 h-12 w-full xl:h-16'>
+              수정 완료
+            </Button>
           </div>
-          <Button className='bg-black-500 h-12 w-full xl:h-16'>수정 완료</Button>
-        </div>
+        </form>
       </div>
     </>
   );

--- a/src/app/(after-login)/epigrams/[id]/edit/page.tsx
+++ b/src/app/(after-login)/epigrams/[id]/edit/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Header from '@/components/ui/header/MainHeader';
 import Button from '@/components/ui/buttons/index';
 import { Pretendard } from '@/fonts';
@@ -5,25 +7,52 @@ import Content from '@/components/edit/Content';
 import Author from '@/components/edit/Author';
 import Source from '@/components/edit/Source';
 import Tags from '@/components/edit/Tags';
+import { useState } from 'react';
 
-// 사실 한 페이지에서 구상을 하려고 했지만 가독성측면에서 분리를 하게됨
-// 1. 해당 페이지에서 가독성을 위해 컴포넌트를 나눔 2. 중복되는 부분이 많다고 판단함 쓸데없이 코드 길어짐 
+// 목데이터로 임시 작업했습니다. 추후 api 작업에서 변경하겠습니다. 
+const mockData = {
+  content: '목데이터 용 내용입니다 .',
+  author: '정재형',
+  source: '유튜브',
+  tags: ['에픽그램', '수정', '예시'],
+};
+
 export default function EpigramEdit() {
+  const [content, setContent] = useState(mockData.content);
+  const [author, setAuthor] = useState(mockData.author);
+  const [source, setSource] = useState(mockData.source);
+  const [tags, setTags] = useState(mockData.tags);
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+  };
+
+  const handleAuthorChange = (value: string) => {
+    setAuthor(value); 
+  };
+
+  const handleSourceChange = (value: string) => {
+    setSource(value); 
+  };
+
+  const handleTagsChange = (newTags: string[]) => {
+    setTags(newTags); 
+  };
+
   return (
     <>
-      <Header></Header>
+      <Header />
       <div className='pt-14'>
         <div className='mx-auto mt-[21px] flex h-196.25 w-78 flex-col gap-6 md:mt-9 md:h-202.75 md:w-[calc(100%-360px)] md:gap-8 xl:mt-20 xl:h-278.5 xl:w-160 xl:gap-10'>
           <p className={`h-6.5 w-full md:h-8 ${Pretendard.className} text-lg font-semibold md:text-xl xl:text-2xl`}>에픽그램 수정</p>
-          <div className='bg-black-400 flex h-165.75 w-full flex-col gap-10 md:h-168.75 xl:h-234.5 xl:gap-13.5'>
-            <Content />
-            <Author />
-            <Source />
-            <Tags />
+          <div className='flex h-165.75 w-full flex-col gap-10 md:h-168.75 xl:h-234.5 xl:gap-13.5'>
+            <Content content={content} onChange={handleContentChange} />
+            <Author author={author} onAuthorChange={handleAuthorChange} />
+            <Source source={source} onSourceChange={handleSourceChange} />
+            <Tags tags={tags} onTagsChange={handleTagsChange} />
           </div>
           <Button className='bg-black-500 h-12 w-full xl:h-16'>수정 완료</Button>
         </div>
-        ;
       </div>
     </>
   );

--- a/src/components/edit/Author.tsx
+++ b/src/components/edit/Author.tsx
@@ -1,13 +1,50 @@
-export default function Author() { // 저자값 텍스트가 -> area에 이동 , 레디오 3칸 골라서 설정할수있는데 본인누르면 본인이름이 -> 
-// 알수없음누르면 그텍스트가, 직접입력누르면 타이핑치게 
+'use client';
+
+import TextArea from '../ui/textarea';
+import { RadioGroup } from '../ui/radio/RadioGroup';
+import { RadioItem } from '../ui/radio/RadioItem';
+import { useState } from 'react';
+
+interface AuthorProps {
+  author: string;
+  onAuthorChange: (value: string) => void;
+}
+
+export default function Author({ author, onAuthorChange }: AuthorProps) {
+  const [selected, setSelected] = useState('myself');
+  const [inputValue, setInputValue] = useState(author);
+
+  const handleRadioChange = (value: string) => {
+    setSelected(value);
+    if (value === 'myself') {
+      setInputValue(author);
+    } else if (value === 'unknown') {
+      setInputValue('알 수 없음');
+    } else {
+      setInputValue('');
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInputValue(e.target.value); // 텍스트 입력값 업데이트
+    onAuthorChange(e.target.value); // 부모에게 상태 변경 알리기
+  };
+
   return (
-    <div className='h-29 w-full bg-amber-600 md:h-29.5 xl:h-42.75'>
-      <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+    <div className='flex h-29 w-full flex-col gap-2 md:h-29.5 xl:h-42.75 xl:gap-6'>
+      <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
         <p className='text-md font-semibold md:text-lg xl:text-xl'>저자</p>
         <p className='flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl'>*</p>
       </div>
 
+      <div className='flex h-20.5 w-full flex-col gap-3 xl:h-28 xl:gap-4'>
+        <RadioGroup className='flex h-6.5 w-full xl:h-8' defaultValue={selected} onValueChange={handleRadioChange}>
+          <RadioItem radioSize='sm' value='custom' id='custom' label='직접 입력' />
+          <RadioItem radioSize='sm' value='unknown' id='unknown' label='알 수 없음' />
+          <RadioItem radioSize='sm' value='myself' id='myself' label='본인' />
+        </RadioGroup>
+        <TextArea size={'source'} maxLength={20} value={inputValue} onChange={handleInputChange} />
+      </div>
     </div>
-    
   );
 }

--- a/src/components/edit/Author.tsx
+++ b/src/components/edit/Author.tsx
@@ -1,0 +1,13 @@
+export default function Author() { // 저자값 텍스트가 -> area에 이동 , 레디오 3칸 골라서 설정할수있는데 본인누르면 본인이름이 -> 
+// 알수없음누르면 그텍스트가, 직접입력누르면 타이핑치게 
+  return (
+    <div className='h-29 w-full bg-amber-600 md:h-29.5 xl:h-42.75'>
+      <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+        <p className='text-md font-semibold md:text-lg xl:text-xl'>저자</p>
+        <p className='flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl'>*</p>
+      </div>
+
+    </div>
+    
+  );
+}

--- a/src/components/edit/Author.tsx
+++ b/src/components/edit/Author.tsx
@@ -3,32 +3,46 @@
 import TextArea from '../ui/textarea';
 import { RadioGroup } from '../ui/radio/RadioGroup';
 import { RadioItem } from '../ui/radio/RadioItem';
-import { useState } from 'react';
+import { UseFormRegister, UseFormWatch, UseFormSetValue } from 'react-hook-form';
+import { useEffect, useState } from 'react';
+
+type FormData = {
+  content: string;
+  author: string;
+  source: string;
+  tags: string[];
+};
 
 interface AuthorProps {
-  author: string;
-  onAuthorChange: (value: string) => void;
+  register: UseFormRegister<FormData>;
+  watch: UseFormWatch<FormData>;
+  setValue: UseFormSetValue<FormData>;
 }
 
-export default function Author({ author, onAuthorChange }: AuthorProps) {
+export default function Author({ register, watch, setValue }: AuthorProps) {
   const [selected, setSelected] = useState('myself');
-  const [inputValue, setInputValue] = useState(author);
+  const authorValue = watch('author');
 
   const handleRadioChange = (value: string) => {
     setSelected(value);
     if (value === 'myself') {
-      setInputValue(author);
+      setValue('author', '본인');
     } else if (value === 'unknown') {
-      setInputValue('알 수 없음');
+      setValue('author', '알 수 없음');
     } else {
-      setInputValue('');
+      setValue('author', '');
     }
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInputValue(e.target.value); // 텍스트 입력값 업데이트
-    onAuthorChange(e.target.value); // 부모에게 상태 변경 알리기
-  };
+  useEffect(() => {
+    if (authorValue === '본인') {
+      setSelected('myself');
+    } else if (authorValue === '알 수 없음') {
+      setSelected('unknown');
+    } else {
+      setSelected('custom');
+    }
+  }, []);
 
   return (
     <div className='flex h-29 w-full flex-col gap-2 md:h-29.5 xl:h-42.75 xl:gap-6'>
@@ -36,14 +50,20 @@ export default function Author({ author, onAuthorChange }: AuthorProps) {
         <p className='text-md font-semibold md:text-lg xl:text-xl'>저자</p>
         <p className='flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl'>*</p>
       </div>
-
+      
       <div className='flex h-20.5 w-full flex-col gap-3 xl:h-28 xl:gap-4'>
         <RadioGroup className='flex h-6.5 w-full xl:h-8' defaultValue={selected} onValueChange={handleRadioChange}>
           <RadioItem radioSize='sm' value='custom' id='custom' label='직접 입력' />
           <RadioItem radioSize='sm' value='unknown' id='unknown' label='알 수 없음' />
           <RadioItem radioSize='sm' value='myself' id='myself' label='본인' />
         </RadioGroup>
-        <TextArea size={'source'} maxLength={20} value={inputValue} onChange={handleInputChange} />
+        <TextArea 
+          size={'source'} 
+          maxLength={20} 
+          value={authorValue}
+          {...register('author', { required: true })}
+          onChange={(e) => setValue('author', e.target.value)}
+        />
       </div>
     </div>
   );

--- a/src/components/edit/Content.tsx
+++ b/src/components/edit/Content.tsx
@@ -1,25 +1,34 @@
+import { UseFormRegister, FieldErrors, UseFormTrigger } from 'react-hook-form';
 import TextArea from '../ui/textarea';
 
 interface ContentProps {
   content: string;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void; 
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  register: UseFormRegister<{ content: string }>;
+  errors: FieldErrors<{ content: string }>;
+  trigger: UseFormTrigger<{ content: string }>;
 }
 
-const Content = ({ content, onChange }: ContentProps) => {
+const Content = ({ content, onChange, register, errors, trigger }: ContentProps) => {
   return (
     <div className="gap-2md:h-42 flex h-41.5 w-full flex-col xl:h-51.75 xl:gap-6">
-      <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+      <div className="flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25">
         <p className="text-md font-semibold md:text-lg xl:text-xl">내용</p>
         <p className="flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl">*</p>
       </div>
       <TextArea
         id="content"
+        {...register('content', { required: '내용을 입력하세요.' })}
         value={content}
         className="relative z-0"
         size={'text'}
         maxLength={500}
-        onChange={onChange} 
+        onChange={(e) => {
+          onChange(e);
+          trigger('content'); // 입력할 때마다 유효성 검사
+        }}
       />
+      {errors.content && <p className="text-red-500 text-sm">{errors.content.message}</p>}
     </div>
   );
 };

--- a/src/components/edit/Content.tsx
+++ b/src/components/edit/Content.tsx
@@ -1,13 +1,25 @@
-import TextArea from '../ui/textarea'; // props로 내용텍스트를 받아서 area 전달을한다
+import TextArea from '../ui/textarea';
 
-const Content = () => {
+interface ContentProps {
+  content: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void; 
+}
+
+const Content = ({ content, onChange }: ContentProps) => {
   return (
-    <div className='flex h-41.5 w-full flex-col gap-2 bg-amber-200 md:h-42 xl:h-51.75 xl:gap-6'>
-      <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
-        <p className='text-md font-semibold md:text-lg xl:text-xl'>내용</p>
-        <p className='flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl'>*</p>
+    <div className="gap-2md:h-42 flex h-41.5 w-full flex-col xl:h-51.75 xl:gap-6">
+      <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+        <p className="text-md font-semibold md:text-lg xl:text-xl">내용</p>
+        <p className="flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl">*</p>
       </div>
-      <TextArea className='w-full h-33' maxLength={500} ></TextArea>
+      <TextArea
+        id="content"
+        value={content}
+        className="relative z-0"
+        size={'text'}
+        maxLength={500}
+        onChange={onChange} 
+      />
     </div>
   );
 };

--- a/src/components/edit/Content.tsx
+++ b/src/components/edit/Content.tsx
@@ -2,33 +2,41 @@ import { UseFormRegister, FieldErrors, UseFormTrigger } from 'react-hook-form';
 import TextArea from '../ui/textarea';
 
 interface ContentProps {
-  content: string;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  register: UseFormRegister<{ content: string }>;
-  errors: FieldErrors<{ content: string }>;
-  trigger: UseFormTrigger<{ content: string }>;
+  register: UseFormRegister<{
+    content: string;
+    author: string;
+    source: string;
+    tags: string[];
+  }>;
+  errors: FieldErrors<{
+    content: string;
+    author: string;
+    source: string;
+    tags: string[];
+  }>;
+  trigger: UseFormTrigger<{
+    content: string;
+    author: string;
+    source: string;
+    tags: string[];
+  }>;
 }
 
-const Content = ({ content, onChange, register, errors, trigger }: ContentProps) => {
+const Content = ({ register, errors, trigger }: ContentProps) => {
   return (
-    <div className="gap-2md:h-42 flex h-41.5 w-full flex-col xl:h-51.75 xl:gap-6">
-      <div className="flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25">
-        <p className="text-md font-semibold md:text-lg xl:text-xl">내용</p>
-        <p className="flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl">*</p>
+    <div className='flex flex-col gap-2'>
+      <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+        <p className='text-md font-semibold md:text-lg xl:text-xl'>내용</p>
+        <p className='flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl'>*</p>
       </div>
       <TextArea
-        id="content"
-        {...register('content', { required: '내용을 입력하세요.' })}
-        value={content}
-        className="relative z-0"
         size={'text'}
-        maxLength={500}
-        onChange={(e) => {
-          onChange(e);
-          trigger('content'); // 입력할 때마다 유효성 검사
-        }}
+        {...register('content', {
+          required: '내용을 입력해주세요',
+          onChange: () => trigger('content'),
+        })}
       />
-      {errors.content && <p className="text-red-500 text-sm">{errors.content.message}</p>}
+      {errors.content && <p className='text-sm text-red-500'>{errors.content.message}</p>}
     </div>
   );
 };

--- a/src/components/edit/Content.tsx
+++ b/src/components/edit/Content.tsx
@@ -1,0 +1,15 @@
+import TextArea from '../ui/textarea'; // props로 내용텍스트를 받아서 area 전달을한다
+
+const Content = () => {
+  return (
+    <div className='flex h-41.5 w-full flex-col gap-2 bg-amber-200 md:h-42 xl:h-51.75 xl:gap-6'>
+      <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+        <p className='text-md font-semibold md:text-lg xl:text-xl'>내용</p>
+        <p className='flex h-3 translate-y-[2px] items-center justify-center text-lg font-medium text-[rgba(255,101,119,1)] xl:translate-y-[3px] xl:text-2xl'>*</p>
+      </div>
+      <TextArea className='w-full h-33' maxLength={500} ></TextArea>
+    </div>
+  );
+};
+
+export default Content;

--- a/src/components/edit/EditForm.tsx
+++ b/src/components/edit/EditForm.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import Button from '@/components/ui/buttons/index';
+import Content from '@/components/edit/Content';
+import Author from '@/components/edit/Author';
+import Source from '@/components/edit/Source';
+import Tags from '@/components/ui/Field/tagsInput';
+
+type FormData = {
+  content: string;
+  author: string;
+  source: string;
+  tags: string[];
+};
+
+interface EpigramEditFormProps {
+  initialData: {
+    content: string;
+    author: string;
+    source: string;
+    tags: string[];
+  };
+}
+
+export default function EpigramEditForm({ initialData }: EpigramEditFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    trigger,
+    watch,
+    setValue,
+    control,
+  } = useForm<FormData>({
+    mode: 'onBlur',
+    defaultValues: {
+      content: initialData.content,
+      author: initialData.author,
+      source: initialData.source,
+      tags: initialData.tags,
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    console.log('제출된 데이터:', data); //todo 디버깅 용입니다.
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='flex h-183.75 flex-col gap-6 md:gap-9.75 xl:gap-10'>
+      <Content register={register} errors={errors} trigger={trigger} />
+      <Author register={register} watch={watch} setValue={setValue} />
+      <Source register={register} />
+      <Tags control={control} errors={errors} />
+      <Button type='submit' className='w-full'>
+        수정 완료
+      </Button>
+    </form>
+  );
+}

--- a/src/components/edit/Source.tsx
+++ b/src/components/edit/Source.tsx
@@ -1,13 +1,18 @@
 import TextArea from '../ui/textarea';
 
-export default function Source() {
-  // 출처를 받아오기만 하면됨 2개로 받아와서 위아래로 나열
+interface SourceProps {
+  source: string;
+  onSourceChange: (value: string) => void;
+}
+
+export default function Source({ source, onSourceChange }: SourceProps) {
   return (
-    <div className='h-32 w-full bg-amber-600 md:h-32.5 xl:h-50'>
-      <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+    <div className='flex h-32 w-full flex-col gap-2 md:h-32.5 xl:h-50 xl:gap-6'>
+      <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
         <p className='text-md font-semibold md:text-lg xl:text-xl'>출처</p>
       </div>
-      <TextArea maxLength={500} size='full'></TextArea>
+      <TextArea size={'source'} maxLength={100} value={source} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onSourceChange(e.target.value)}></TextArea>
+      <TextArea size={'source'} maxLength={100} value={source} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onSourceChange(e.target.value)}></TextArea>
     </div>
   );
 }

--- a/src/components/edit/Source.tsx
+++ b/src/components/edit/Source.tsx
@@ -1,18 +1,33 @@
 import TextArea from '../ui/textarea';
+import { UseFormRegister } from 'react-hook-form';
+
+type FormData = {
+  content: string;
+  author: string;
+  source: string;
+  tags: string[];
+};
 
 interface SourceProps {
-  source: string;
-  onSourceChange: (value: string) => void;
+  register: UseFormRegister<FormData>;
 }
 
-export default function Source({ source, onSourceChange }: SourceProps) {
+export default function Source({ register }: SourceProps) {
   return (
     <div className='flex h-32 w-full flex-col gap-2 md:h-32.5 xl:h-50 xl:gap-6'>
       <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
         <p className='text-md font-semibold md:text-lg xl:text-xl'>출처</p>
       </div>
-      <TextArea size={'source'} maxLength={100} value={source} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onSourceChange(e.target.value)}></TextArea>
-      <TextArea size={'source'} maxLength={100} value={source} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onSourceChange(e.target.value)}></TextArea>
+      <TextArea 
+        size={'source'} 
+        maxLength={100} 
+        {...register('source')}
+      />
+            <TextArea 
+        size={'source'} 
+        maxLength={100} 
+        {...register('source')}
+      />
     </div>
   );
 }

--- a/src/components/edit/Source.tsx
+++ b/src/components/edit/Source.tsx
@@ -1,0 +1,13 @@
+import TextArea from '../ui/textarea';
+
+export default function Source() {
+  // 출처를 받아오기만 하면됨 2개로 받아와서 위아래로 나열
+  return (
+    <div className='h-32 w-full bg-amber-600 md:h-32.5 xl:h-50'>
+      <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+        <p className='text-md font-semibold md:text-lg xl:text-xl'>출처</p>
+      </div>
+      <TextArea maxLength={500} size='full'></TextArea>
+    </div>
+  );
+}

--- a/src/components/edit/Tags.tsx
+++ b/src/components/edit/Tags.tsx
@@ -46,7 +46,7 @@ export default function Tags({ tags, onTagsChange }: TagsProps) {
               {tags.map((tag, index) => (
                 <span key={index} className='relative flex h-full items-center justify-center rounded-full bg-gray-100 px-4 py-1 text-lg md:text-xl xl:text-2xl'>
                   {tag}
-                  <button type='button' className='text-md absolute top-[5px] right-[4px] text-red-500 hover:text-red-700 md:top-[8px] xl:top-[11px]' onClick={() => handleRemoveTag(tag)}>
+                  <button type='button' className='text-md absolute top-[5px] md:top-[8px] right-[4px] xl:top-[11px]  text-red-500 hover:text-red-700 ' onClick={() => handleRemoveTag(tag)}>
                     &times;
                   </button>
                 </span>

--- a/src/components/edit/Tags.tsx
+++ b/src/components/edit/Tags.tsx
@@ -1,10 +1,60 @@
-export default function Tags() { //tag값을 받아와야겠지 -> 태그 추가 기능과 가져온 태그를 나열
-    return (
-      <div className='h-32 w-full bg-amber-600 md:h-32.5 xl:h-50'>
-        <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
-          <p className='text-md font-semibold md:text-lg xl:text-xl'>태그</p>
+'use client';
+
+import TextArea from '../ui/textarea';
+import { useState } from 'react';
+
+interface TagsProps {
+  tags: string[];
+  onTagsChange: (tags: string[]) => void;
+}
+
+export default function Tags({ tags, onTagsChange }: TagsProps) {
+  const [newTag, setNewTag] = useState('');
+
+  const handleTagInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setNewTag(e.target.value);
+  };
+
+  const handleAddTag = () => {
+    if (newTag.trim() && !tags.includes(newTag.trim())) {
+      // 비어있지 않고 중복되지 않으면
+      onTagsChange([...tags, newTag.trim()]); // 태그 추가
+      setNewTag(''); // 입력 필드 초기화
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter') {
+      handleAddTag(); // 엔터키 눌렀을 때 태그 추가
+    }
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    onTagsChange(tags.filter((tag) => tag !== tagToRemove)); // 삭제할 태그를 제외한 나머지 태그들로 상태 업데이트
+  };
+
+  return (
+    <div className='flex h-32 w-full flex-col gap-2 md:h-35.5 xl:h-49.5 xl:gap-6'>
+      <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+        <p className='text-md font-semibold md:text-lg xl:text-xl'>태그</p>
+      </div>
+      <div className='flex h-25.25 w-full flex-col gap-3.75 md:h-27 md:gap-4 xl:h-35.5 xl:gap-5.5'>
+        <TextArea placeholder='입력하여 태그 작성 (최대 10자)' size={'source'} maxLength={10} value={newTag} onChange={handleTagInputChange} onKeyDown={handleKeyDown} />
+        <div className='h-10.5 w-full md:h-12 xl:h-14'>
+          {tags.length > 0 && (
+            <div className='flex h-full flex-wrap gap-2 xl:gap-4'>
+              {tags.map((tag, index) => (
+                <span key={index} className='relative flex h-full items-center justify-center rounded-full bg-gray-100 px-4 py-1 text-lg md:text-xl xl:text-2xl'>
+                  {tag}
+                  <button type='button' className='text-md absolute top-[5px] right-[4px] text-red-500 hover:text-red-700 md:top-[8px] xl:top-[11px]' onClick={() => handleRemoveTag(tag)}>
+                    &times;
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       </div>
-    );
-  }
-  
+    </div>
+  );
+}

--- a/src/components/edit/Tags.tsx
+++ b/src/components/edit/Tags.tsx
@@ -1,60 +1,85 @@
 'use client';
 
-import TextArea from '../ui/textarea';
 import { useState } from 'react';
+import TextArea from '../ui/textarea';
+import XIcon from '@/assets/icons/X.svg';
+import Image from 'next/image';
 
-interface TagsProps {
-  tags: string[];
-  onTagsChange: (tags: string[]) => void;
+interface TagInputProps {
+  value: string[];
+  onChange: (value: string[]) => void;
+  label?: string;
+  required?: boolean;
+  error?: string;
 }
 
-export default function Tags({ tags, onTagsChange }: TagsProps) {
+export default function TagInput({ value = [], onChange, label = '태그', required, error }: TagInputProps) {
   const [newTag, setNewTag] = useState('');
+  const [showAll, setShowAll] = useState(false); // 태그 모두 보기 토글 상태
 
   const handleTagInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setNewTag(e.target.value);
   };
 
   const handleAddTag = () => {
-    if (newTag.trim() && !tags.includes(newTag.trim())) {
-      // 비어있지 않고 중복되지 않으면
-      onTagsChange([...tags, newTag.trim()]); // 태그 추가
-      setNewTag(''); // 입력 필드 초기화
+    if (newTag.trim() && !value.includes(newTag.trim()) && value.length < 3) {
+      onChange([...value, newTag.trim()]);
+      setNewTag('');
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      handleAddTag(); // 엔터키 눌렀을 때 태그 추가
+      e.preventDefault();
+      handleAddTag();
     }
   };
 
   const handleRemoveTag = (tagToRemove: string) => {
-    onTagsChange(tags.filter((tag) => tag !== tagToRemove)); // 삭제할 태그를 제외한 나머지 태그들로 상태 업데이트
+    onChange(value.filter((tag) => tag !== tagToRemove));
   };
 
   return (
-    <div className='flex h-32 w-full flex-col gap-2 md:h-35.5 xl:h-49.5 xl:gap-6'>
-      <div className={`flex h-6.5 w-9.5 items-center justify-between md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
-        <p className='text-md font-semibold md:text-lg xl:text-xl'>태그</p>
+    <div className='flex w-full flex-col gap-2 md:gap-4 xl:gap-6'>
+      <div className='flex items-center justify-between'>
+        <p className='text-md font-semibold md:text-lg xl:text-xl'>{label}</p>
+        {required && <p className='text-lg font-medium text-red-500'>*</p>}
       </div>
-      <div className='flex h-25.25 w-full flex-col gap-3.75 md:h-27 md:gap-4 xl:h-35.5 xl:gap-5.5'>
-        <TextArea placeholder='입력하여 태그 작성 (최대 10자)' size={'source'} maxLength={10} value={newTag} onChange={handleTagInputChange} onKeyDown={handleKeyDown} />
-        <div className='h-10.5 w-full md:h-12 xl:h-14'>
-          {tags.length > 0 && (
-            <div className='flex h-full flex-wrap gap-2 xl:gap-4'>
-              {tags.map((tag, index) => (
-                <span key={index} className='relative flex h-full items-center justify-center rounded-full bg-gray-100 px-4 py-1 text-lg md:text-xl xl:text-2xl'>
-                  {tag}
-                  <button type='button' className='text-md absolute top-[5px] md:top-[8px] right-[4px] xl:top-[11px]  text-red-500 hover:text-red-700 ' onClick={() => handleRemoveTag(tag)}>
-                    &times;
-                  </button>
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
+
+      <TextArea
+        placeholder='입력하여 태그 작성 (최대 10자, 최대 3개)'
+        value={newTag}
+        onChange={handleTagInputChange}
+        onKeyDown={handleKeyDown}
+        size={'source'}
+        disabled={value.length >= 3} // 3개 이상이면 입력창 비활성화
+      />
+
+      {/* 태그 목록 */}
+      <div className='flex flex-wrap gap-2'>
+        {(showAll ? value : value.slice(0, 2)).map((tag, index) => (
+          <span key={index} className='relative flex items-center rounded-full bg-gray-100 px-4 py-1 text-lg'>
+            {tag}
+            <button type='button' className='ml-2' onClick={() => handleRemoveTag(tag)}>
+              <Image src={XIcon} alt='XIcon' />
+            </button>
+          </span>
+        ))}
+
+        {/* 더보기 버튼 */}
+        {value.length > 2 && !showAll && (
+          <button className='text-blue-500 hover:underline' onClick={() => setShowAll(true)}>
+            +{value.length - 2}개 더보기
+          </button>
+        )}
+        {showAll && (
+          <button className='text-blue-500 hover:underline' onClick={() => setShowAll(false)}>
+            닫기
+          </button>
+        )}
       </div>
+
+      {error && <p className='text-sm text-red-500'>{error}</p>}
     </div>
   );
 }

--- a/src/components/edit/Tags.tsx
+++ b/src/components/edit/Tags.tsx
@@ -1,0 +1,10 @@
+export default function Tags() { //tag값을 받아와야겠지 -> 태그 추가 기능과 가져온 태그를 나열
+    return (
+      <div className='h-32 w-full bg-amber-600 md:h-32.5 xl:h-50'>
+        <div className={`flex h-6.5 w-9.5 items-center justify-between bg-amber-50 md:h-7 md:w-10.25 xl:h-8.75 xl:w-13.25`}>
+          <p className='text-md font-semibold md:text-lg xl:text-xl'>태그</p>
+        </div>
+      </div>
+    );
+  }
+  

--- a/src/components/ui/Field/tagsInput.tsx
+++ b/src/components/ui/Field/tagsInput.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Control, Controller, FieldErrors } from 'react-hook-form';
+import TagInput from '@/components/edit/Tags';
+
+type FormData = {
+  content: string;
+  author: string;
+  source: string;
+  tags: string[];
+};
+
+interface TagsProps {
+  control: Control<FormData>;
+  errors: FieldErrors<FormData>;
+}
+
+export default function Tags({ control, errors }: TagsProps) {
+  return <Controller name='tags' control={control} defaultValue={[]} render={({ field }) => <TagInput value={field.value || []} onChange={field.onChange} error={errors.tags?.message} />} />;
+}

--- a/src/components/ui/header/MainHeader.tsx
+++ b/src/components/ui/header/MainHeader.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 
 export default function MainHeader() {
   return (
-    <header className='border-b-line-100 fixed flex w-full items-center justify-between border-b-[1px] bg-white px-6 py-[13px] md:px-[72px] md:py-[17px] xl:px-[120px] xl:py-[22px]'>
+    <header className='border-b-line-100 fixed flex w-full items-center justify-between border-b-[1px] bg-white px-6 py-[13px] md:px-[72px] md:py-[17px] xl:px-[120px] xl:py-[22px] z-50'>
       <div className='flex items-center justify-center gap-3 md:gap-6 xl:gap-9'>
         <Image src={menuIcon} alt='메뉴 아이콘' className='md:hidden'></Image>
         <Link href={'/'}>

--- a/src/components/ui/radio/RadioLabel.tsx
+++ b/src/components/ui/radio/RadioLabel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { HTMLAttributes, ReactNode } from 'react';
-import { cn } from '@/utils/cn';
+import { cn } from '@/utils/cn'; 
 
 export interface RadioLabelProps extends HTMLAttributes<HTMLLabelElement> {
   htmlFor: string;

--- a/src/components/ui/radio/RadioLabel.tsx
+++ b/src/components/ui/radio/RadioLabel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { HTMLAttributes, ReactNode } from 'react';
-import { cn } from '@/utils/cn'; 
+import { cn } from '@/utils/cn';
 
 export interface RadioLabelProps extends HTMLAttributes<HTMLLabelElement> {
   htmlFor: string;

--- a/src/components/ui/textarea/index.tsx
+++ b/src/components/ui/textarea/index.tsx
@@ -17,7 +17,8 @@ const textAreaVariants = cva('bg-white placeholder-blue-300', {
       sm: 'w-[312px] h-[132px] pt-[10px] pb-[96px] px-[16px]',
       md: 'w-sm h-[132px] pt-[10px] pb-[96px] px-[16px]',
       lg: 'w-[640px] h-[148px] pt-[10px] pb-[106px] px-[16px]',
-      //full: 'w-full h-[132px] xl:h-[148px]', //full 추가했어요 
+      text: 'w-full h-[132px] xl:h-[148px]', // 우선 사이즈 디폴트가 사라지지 않아서 반응형 작업에 문제가 생기더라구요 일단 이렇게 작업하고 추후에 수정하겠습니다<div className=""></div>
+      source: 'w-full h-[44px] xl:h-[64px]',
     },
     fontSize: {
       base: 'text-base',
@@ -48,9 +49,7 @@ export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   ref?: Ref<HTMLTextAreaElement>;
 }
 
-
-export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ref, ...props }: TextAreaProps) {
-
+export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ref, className, placeholder, ...props }: TextAreaProps) {
   const initialValue = value?.toString() || defaultValue?.toString() || '';
 
   const [charCount, setCharCount] = useState(initialValue.length);
@@ -87,12 +86,16 @@ export default function TextArea({ variant, size, fontSize, border, borderRadius
   return (
     <div className='relative'>
       <textarea
-        className={cn(textAreaVariants({ variant, size, fontSize, border, borderRadius,className  }))}
+        className={cn(textAreaVariants({ variant, size, fontSize, border, borderRadius, className }))}
         onChange={handleChange}
         maxLength={effectiveMaxLength}
         value={value}
         defaultValue={defaultValue}
         ref={ref}
+        placeholder={placeholder}
+        style={{
+          padding: '10px 16px', // 플레이스홀더가 들어갈 안쪽 패딩 설정
+        }}
         {...props}
       />
 

--- a/src/components/ui/textarea/index.tsx
+++ b/src/components/ui/textarea/index.tsx
@@ -17,6 +17,7 @@ const textAreaVariants = cva('bg-white placeholder-blue-300', {
       sm: 'w-[312px] h-[132px] pt-[10px] pb-[96px] px-[16px]',
       md: 'w-sm h-[132px] pt-[10px] pb-[96px] px-[16px]',
       lg: 'w-[640px] h-[148px] pt-[10px] pb-[106px] px-[16px]',
+      //full: 'w-full h-[132px] xl:h-[148px]', //full 추가했어요 
     },
     fontSize: {
       base: 'text-base',
@@ -47,7 +48,9 @@ export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   ref?: Ref<HTMLTextAreaElement>;
 }
 
+
 export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ref, ...props }: TextAreaProps) {
+
   const initialValue = value?.toString() || defaultValue?.toString() || '';
 
   const [charCount, setCharCount] = useState(initialValue.length);
@@ -84,7 +87,7 @@ export default function TextArea({ variant, size, fontSize, border, borderRadius
   return (
     <div className='relative'>
       <textarea
-        className={cn(textAreaVariants({ variant, size, fontSize, border, borderRadius }))}
+        className={cn(textAreaVariants({ variant, size, fontSize, border, borderRadius,className  }))}
         onChange={handleChange}
         maxLength={effectiveMaxLength}
         value={value}


### PR DESCRIPTION
## ❓이슈
- close #59 

## :writing_hand: Description

우선 수정 페이지의 전반적인 UI 작성을 끝냈고
목업 데이터를 이용해서 일단 데이터를 받았습니다
api 작업은 새로 이슈를 파서 작업 하겠습니다 .
그리고 성락님 말씀대로 e2e도 따로 빼서 이슈 처리하겠습니다.

현재 피드백 받은 내용이 우선순위가 높아 일단 PR 올립니다 ! 

**-- 도균님의 피드백 먼저 수정하고 다시 올리겠습니다 --**

1. 폼 컴포넌트를 따로 뺴서  'use client’;를 없애주고 

2. On submit - >  콘솔은 todo 노란색으로 디버깅용으로 

3. 리액트 훅 폼에 register 이용  -> 유스테이트 필요없음 

4. Tags input은 특수한 인풋이니 리액트 훗폼 컨트롤러를 이용해서 태그스를 컴포넌트로 ui 필드에다가 컴포넌트 태그인풋 컨트롤러로 제어할 수 있게 

---- 

공용 컴포넌트 수정사항이 있었습니다 

1. 텍스트 에어리어 컴포넌트를 사용하고 있는데-> 도균님이 디코에 남겨주신것처럼 디폴트 사이즈가 없는채로 커스텀이 안되서
임시로 size - 부분에 두가지 사이즈 추가해서 작업을 임시로 했습니다 . > 
리팩토링 pr올려주시면 추후에 수정을 하겠습니다

**+플레이스 홀더 패딩 10. 16 10 16 이렇게줘서 너무 첫부분에서 시작하지않고 피그마 시안처럼 중간에서 시작하게 했습니다.**

**2. Main header -  스크롤링할때 헤더보다 내부 텍스트들이 위에있는게 생겨서 > z-index 50추가해줬읍니다**

# 영상 내용 (태그부분처리)

- 태그 처리를 어떻게 할까 하다가 다음과 같이 진행했습니다 .
- 태그 3개 이상은 허용하지 않으면서 
- 더보기 누르면 보이게 깔끔하게 처리를 시도 해 봤습니다. (길이 생각해서)
- 이렇게 작업한 이유는 데스크 탑일 때는 크게 문제가 되지는 않지만, 모바일 일 때를 고려 했습니다.

https://github.com/user-attachments/assets/9c54c617-34de-415a-b9a8-a3e9a8489842






<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

- [x] 에픽그램 수정 페이지 UI 구현 
- [x]  react hook form을 통한 유효성 검사 

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
