### PR TITLE
EP-65 comment 서비스 로직 구현

### DIFF
--- a/src/apis/comment/index.ts
+++ b/src/apis/comment/index.ts
@@ -42,5 +42,5 @@ export const patchComment = async (commentId: number, patchComment: PatchComment
  * https://fe-project-epigram-api.vercel.app/docs/#/Comment/DeleteComment
  */
 export const deleteComment = async (commentId: number) => {
-  await axiosClientHelper.delete<void>(`/comments/${commentId}`);
+  await axiosClientHelper.delete<{ id: number }>(`/comments/${commentId}`);
 };

--- a/src/apis/comment/index.ts
+++ b/src/apis/comment/index.ts
@@ -1,0 +1,46 @@
+import axiosClientHelper from '@/utils/network/axiosClientHelper';
+import { Comment, CommentForm, CommentsResponse, PatchComment } from './types';
+import { safeResponse } from '@/utils/network/safeResponse';
+import { commentSchema, commentsResponseSchema } from './schemas';
+
+/**
+ *
+ * comment 생성
+ * https://fe-project-epigram-api.vercel.app/docs/#/Comment/CreateComment
+ */
+export const postComment = async (commentForm: CommentForm) => {
+  const response = await axiosClientHelper.post<Comment>('/comments', commentForm);
+  return safeResponse(response.data, commentSchema);
+};
+
+/**
+ * comments 목록 조회
+ * https://fe-project-epigram-api.vercel.app/docs/#/Comment/ListComments
+ */
+export const getComments = async (limit: number, cursor?: number) => {
+  const params: { limit: number; cursor?: number } = { limit };
+  if (cursor !== undefined) {
+    params.cursor = cursor;
+  }
+  const response = await axiosClientHelper.get<CommentsResponse>('/comments', {
+    params,
+  });
+  return safeResponse(response.data, commentsResponseSchema);
+};
+
+/**
+ * comment 수정
+ * https://fe-project-epigram-api.vercel.app/docs/#/Comment/UpdateComment
+ */
+export const patchComment = async (commentId: number, patchComment: PatchComment) => {
+  const response = await axiosClientHelper.patch<PatchComment>(`/comments/${commentId}`, patchComment);
+  return safeResponse(response.data, commentSchema);
+};
+
+/**
+ * comment 삭제
+ * https://fe-project-epigram-api.vercel.app/docs/#/Comment/DeleteComment
+ */
+export const deleteComment = async (commentId: number) => {
+  await axiosClientHelper.delete<void>(`/comments/${commentId}`);
+};

--- a/src/apis/comment/index.ts
+++ b/src/apis/comment/index.ts
@@ -2,6 +2,7 @@ import axiosClientHelper from '@/utils/network/axiosClientHelper';
 import { Comment, CommentForm, CommentsResponse, PatchComment } from './types';
 import { safeResponse } from '@/utils/network/safeResponse';
 import { commentSchema, commentsResponseSchema } from './schemas';
+import { z } from 'zod';
 
 /**
  *
@@ -32,8 +33,8 @@ export const getComments = async (limit: number, cursor?: number) => {
  * comment 수정
  * https://fe-project-epigram-api.vercel.app/docs/#/Comment/UpdateComment
  */
-export const patchComment = async (commentId: number, patchComment: PatchComment) => {
-  const response = await axiosClientHelper.patch<PatchComment>(`/comments/${commentId}`, patchComment);
+export const patchComment = async (commentId: number, comment: PatchComment) => {
+  const response = await axiosClientHelper.patch<PatchComment>(`/comments/${commentId}`, comment);
   return safeResponse(response.data, commentSchema);
 };
 
@@ -42,5 +43,6 @@ export const patchComment = async (commentId: number, patchComment: PatchComment
  * https://fe-project-epigram-api.vercel.app/docs/#/Comment/DeleteComment
  */
 export const deleteComment = async (commentId: number) => {
-  await axiosClientHelper.delete<{ id: number }>(`/comments/${commentId}`);
+  const response = await axiosClientHelper.delete<{ id: number }>(`/comments/${commentId}`);
+  return safeResponse(response.data, z.object({ id: z.number() }));
 };

--- a/src/apis/comment/queries.tsx
+++ b/src/apis/comment/queries.tsx
@@ -33,7 +33,7 @@ export const useUpdateComment = () => {
   });
 };
 
-export const useDeleteCommentMutation = () => {
+export const useDeleteComment = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (commentId: number) => deleteComment(commentId),

--- a/src/apis/comment/queries.tsx
+++ b/src/apis/comment/queries.tsx
@@ -1,0 +1,45 @@
+import { InfiniteData, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteComment, getComments, patchComment, postComment } from '.';
+import { CommentForm, CommentsResponse, PatchComment } from './types';
+
+export const useCommentsQuery = (limit: number) => {
+  return useInfiniteQuery<CommentsResponse, Error, InfiniteData<CommentsResponse>, [string, number], number | undefined>({
+    queryKey: ['comments', limit],
+    queryFn: ({ pageParam = undefined }) => getComments(limit, pageParam),
+    getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
+    initialPageParam: undefined,
+  });
+};
+
+export const usePostComment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (formData: CommentForm) => postComment(formData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
+      queryClient.invalidateQueries({ queryKey: ['epigramComments'] });
+    },
+  });
+};
+
+export const useUpdateComment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { commentId: number; patchData: PatchComment }) => patchComment(data.commentId, data.patchData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
+      queryClient.invalidateQueries({ queryKey: ['epigramComments'] });
+    },
+  });
+};
+
+export const useDeleteCommentMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (commentId: number) => deleteComment(commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
+      queryClient.invalidateQueries({ queryKey: ['epigramComments'] });
+    },
+  });
+};

--- a/src/apis/comment/schemas.ts
+++ b/src/apis/comment/schemas.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const commentSchema = z.object({
+  epigramId: z.number(),
+  writer: z.object({
+    image: z.string().nullable(),
+    nickname: z.string(),
+    id: z.number(),
+  }),
+  updatedAt: z.string(),
+  createdAt: z.string(),
+  isPrivate: z.boolean(),
+  content: z.string().min(1),
+  id: z.number(),
+});
+
+export const commentFormSchema = z.object({
+  epigramId: z.number(),
+  isPrivate: z.boolean(),
+  content: z.string().trim().min(1),
+});
+
+export const getCommentsParamsSchema = z.object({
+  totalCount: z.number(),
+  nextCursor: z.number().nullable(),
+  list: z.array(commentSchema),
+});
+
+export const patchCommentSchema = z.object({
+  isPrivate: z.boolean(),
+  content: z.string().trim().min(1),
+});

--- a/src/apis/comment/schemas.ts
+++ b/src/apis/comment/schemas.ts
@@ -10,7 +10,7 @@ export const commentSchema = z.object({
   updatedAt: z.string(),
   createdAt: z.string(),
   isPrivate: z.boolean(),
-  content: z.string().min(1),
+  content: z.string(),
   id: z.number(),
 });
 
@@ -20,13 +20,10 @@ export const commentFormSchema = z.object({
   content: z.string().trim().min(1),
 });
 
-export const getCommentsParamsSchema = z.object({
+export const commentsResponseSchema = z.object({
   totalCount: z.number(),
   nextCursor: z.number().nullable(),
   list: z.array(commentSchema),
 });
 
-export const patchCommentSchema = z.object({
-  isPrivate: z.boolean(),
-  content: z.string().trim().min(1),
-});
+export const patchCommentSchema = commentFormSchema.omit({ epigramId: true }).partial();

--- a/src/apis/comment/types.ts
+++ b/src/apis/comment/types.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { commentFormSchema, commentSchema, commentsResponseSchema, patchCommentSchema } from './schemas';
+
+export type Comment = z.infer<typeof commentSchema>;
+
+export type CommentForm = z.infer<typeof commentFormSchema>;
+
+export type CommentsResponse = z.infer<typeof commentsResponseSchema>;
+
+export type PatchComment = z.infer<typeof patchCommentSchema>;


### PR DESCRIPTION
## ❓이슈
- close #83

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
- Comment 도메인의 서비스 로직(api, query hook, types, schemas) 관련 PR입니다.
- 훅 동작 여부 로컬에서 테스트 완료했습니다.
- GET : 한 페이지당 불러올 댓글 수(limit)를 인자로 넘겨주면 됩니다.
- POST : 댓글 작성 폼 데이터(CommentForm)를 인자로 전달하면 됩니다.
- PATCH : 수정할 댓글의 ID와 변경할 데이터(PatchComment)를 함께 전달하면 됩니다.
- DELETE : 삭제할 댓글의 ID만 전달하면 됩니다.

- `useCommentQuery` 는 훅이 API 응답에서 `nextCursor`값을 추출해서 무한 스크롤이나, 더 보기 버튼 처리 자동으로 하게 했습니다.



## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
