### PR TITLE
EP-52 에피그램 생성 페이지 구현

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,18 +1,18 @@
-import type { Config } from "jest";
-import nextJest from "next/jest.js";
+import type { Config } from 'jest';
+import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({
-  dir: "./",
+  dir: './',
 });
 
 const config: Config = {
-  coverageProvider: "v8",
-  testEnvironment: "jsdom",
-  testPathIgnorePatterns: ["/node_modules/", "/e2e/"],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
-  transformIgnorePatterns: ["/node_modules/", "^.+\\.module\\.(css|sass|scss)$"],
+  coverageProvider: 'v8',
+  testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  transformIgnorePatterns: ['/node_modules/', '^.+\\.module\\.(css|sass|scss)$'],
   moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
 };
 

--- a/src/apis/auth/schemas.ts
+++ b/src/apis/auth/schemas.ts
@@ -30,3 +30,11 @@ export const loginSchema = z.object({
   email: z.string().min(1, '이메일은 필수 입력입니다.').email('이메일 형식으로 작성해 주세요.'),
   password: z.string().min(1, '비밀번호는 필수 입력입니다.'),
 });
+
+export const MakeEpigramFormSchema = z.object({
+  content: z.string().min(1, '내용을 입력해주세요.').max(500, '500자를 초과할 수 없습니다'),
+  authorType: z.enum(['direct', 'unknown', 'self']),
+  authorName: z.string().optional().pipe(z.string().min(1, '저자 이름을 입력해주세요').optional()),
+  sourceTitle: z.string().optional(),
+  sourceUrl: z.union([z.literal(''), z.string().url('올바른 URL 형식이 아닙니다')]).optional(),
+});

--- a/src/apis/auth/types.ts
+++ b/src/apis/auth/types.ts
@@ -1,6 +1,16 @@
 import { z } from 'zod';
-import { loginSchema, signupSchema } from './schemas';
+import { loginSchema, MakeEpigramFormSchema, signupSchema } from './schemas';
 
 export type SignupForm = z.infer<typeof signupSchema>;
 
 export type LoginForm = z.infer<typeof loginSchema>;
+
+export type MakeEpigramForm = z.infer<typeof MakeEpigramFormSchema>;
+
+export interface MakeEpigramApiRequest {
+  tags: string[];
+  referenceUrl: string;
+  referenceTitle: string;
+  author: string;
+  content: string;
+}

--- a/src/app/(after-login)/addepigram/page.tsx
+++ b/src/app/(after-login)/addepigram/page.tsx
@@ -1,3 +1,5 @@
-export default function AddEpigram() {
-  return <div>에피그램 생성 페이지</div>;
+import AddEpigramForm from '@/components/form/AddEpigramForm';
+
+export default function AddEpigramPage() {
+  return <AddEpigramForm />;
 }

--- a/src/components/form/AddEpigramForm.tsx
+++ b/src/components/form/AddEpigramForm.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import Button from '@/components/ui/buttons';
+import Input from '@/components/ui/Field/Input';
+import MainHeader from '@/components/ui/header/MainHeader';
+import { RadioGroup } from '@/components/ui/radio/RadioGroup';
+import { RadioItem } from '@/components/ui/radio/RadioItem';
+import TextArea from '@/components/ui/textarea';
+import { Pretendard } from '@/fonts';
+import { MakeEpigramFormSchema } from '@/apis/auth/schemas';
+import { MakeEpigramForm } from '@/types';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+
+export default function AddEpigramForm() {
+  const {
+    handleSubmit,
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<MakeEpigramForm>({
+    resolver: zodResolver(MakeEpigramFormSchema),
+    defaultValues: {
+      authorType: 'direct',
+    },
+    mode: 'onBlur',
+  });
+
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
+  const [showAll, setShowAll] = useState(false); // 태그 모두 보기 토글 상태
+
+  const addTag = () => {
+    if (tagInput && tagInput.length <= 10 && tagInput.length > 0) {
+      setTags([...tags, tagInput]);
+      setTagInput('');
+    }
+  };
+
+  const removeTag = (index: number) => {
+    setTags(tags.filter((_, i) => i !== index));
+  };
+
+  const onSubmit: SubmitHandler<MakeEpigramForm> = (data) => {
+    const formData = {
+      ...data,
+      tags,
+    };
+    console.log(formData);
+    // TODO: API 호출
+  };
+
+  const authorType = watch('authorType');
+  const content = watch('content', '');
+
+  const handleRadioChange = (value: string) => {
+    const typedValue = value as 'direct' | 'unknown' | 'self';
+    setValue('authorType', typedValue, { shouldValidate: true });
+  };
+
+  return (
+    <div className='flex flex-col'>
+      <MainHeader />
+      <div className='flex-grow py-6 md:py-8 lg:py-14'>
+        <form onSubmit={handleSubmit(onSubmit)} className='mx-auto w-[312px] pt-10 md:pt-12 lg:w-[640px] lg:pt-14'>
+          <div className={`${Pretendard.className} h-6 w-full text-lg font-semibold md:h-8 md:text-xl lg:h-8 lg:text-2xl`}>에피그램 만들기</div>
+          <div className='mt-6 h-auto md:mt-8 lg:mt-10'>
+            <label className={`${Pretendard.className} text-md font-semibold md:text-lg lg:text-xl`}>내용</label>
+            <TextArea
+              variant='limit500'
+              size='responsive'
+              fontSize='responsive'
+              border='blue-border'
+              placeholder='500자 이내로 입력해주세요.'
+              {...register('content', {
+                required: '내용을 입력해주세요',
+                maxLength: { value: 500, message: '500자를 초과할 수 없습니다' },
+              })}
+              className='mt-2 lg:mt-6'
+            />
+            {errors.content && <p className='text-md mt-1 text-red-500 lg:text-lg'>{errors.content.message}</p>}
+          </div>
+          <div className='mt-10 xl:mt-14'>
+            <label className={`${Pretendard.className} text-md font-semibold md:text-lg lg:text-xl`}>저자</label>
+            <RadioGroup defaultValue={authorType} onValueChange={handleRadioChange} className='mt-2 lg:mt-6'>
+              <RadioItem value='direct' id='direct' label='직접 입력' radioSize='sm' />
+              <RadioItem value='unknown' id='unknown' label='알 수 없음' radioSize='sm' />
+              <RadioItem value='self' id='self' label='본인' radioSize='sm' />
+            </RadioGroup>
+            {authorType === 'direct' && (
+              <Input
+                placeholder='저자 이름 입력'
+                {...register('authorName', { required: authorType === 'direct' ? '저자 이름을 입력해주세요' : false })}
+                error={errors.authorName?.message}
+                className='mt-3 text-lg lg:mt-4 lg:text-xl'
+              />
+            )}
+          </div>
+          <div className='mt-10 lg:mt-14'>
+            <label className={`${Pretendard.className} text-md font-semibold md:text-lg lg:text-xl`}>출처</label>
+            <Input placeholder='출처 제목 입력' {...register('sourceTitle')} className='mt-2 text-lg lg:mt-6 lg:text-xl' />
+            <Input placeholder='URL (ex. https://www.website.com/)' {...register('sourceUrl')} error={errors.sourceUrl?.message} className='mt-2 text-lg lg:mt-4 lg:text-xl' />
+          </div>
+
+          <div className='mt-10 lg:mt-14'>
+            <label className={`${Pretendard.className} text-md font-semibold md:text-lg lg:text-xl`}>태그</label>
+            <div className='mt-2 flex lg:mt-6'>
+              <div className='w-3/4 lg:w-4/5'>
+                <Input placeholder='입력하여 태그 작성 (최대 10자)' value={tagInput} onChange={(e) => setTagInput(e.target.value)} className='text-lg lg:text-xl' />
+              </div>
+              <Button type='button' variant='default' onClick={addTag} disabled={!tagInput || tagInput.length > 10} className='ml-2 w-1/4 text-sm whitespace-nowrap lg:w-1/5 lg:text-xl'>
+                추가
+              </Button>
+            </div>
+
+            {tagInput.length > 10 && <p className='text-md mt-1 text-red-500 lg:text-lg'>태그는 10자를 초과할 수 없습니다</p>}
+
+            {tags.length >= 3 && <p className='text-md mt-1 text-amber-500 lg:text-lg'>태그는 최대 3개까지 추가할 수 있습니다</p>}
+
+            {tags.length > 0 && (
+              <div className='mt-2 flex flex-wrap gap-2 lg:mt-3'>
+                {(showAll ? tags : tags.slice(0, 2)).map((tag, index) => (
+                  <div key={index} className='flex items-center rounded-full bg-blue-100 px-3 py-1'>
+                    {tag}
+                    <button type='button' onClick={() => removeTag(index)} className='ml-1 text-blue-500 lg:ml-2'>
+                      ×
+                    </button>
+                  </div>
+                ))}
+                {!showAll && tags.length > 2 && (
+                  <button className='text-blue-500 hover:underline' onClick={() => setShowAll(true)}>
+                    +{tags.length - 2}개 더보기
+                  </button>
+                )}
+                {showAll && tags.length > 2 && (
+                  <button className='text-blue-500 hover:underline' onClick={() => setShowAll(false)}>
+                    닫기
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+          <div className='mt-6 mb-7 lg:mb-14 xl:mt-10'>
+            <Button type='submit' variant='default' className='w-full' disabled={content.length > 500 || content.length < 1 || (authorType === 'direct' && !watch('authorName'))}>
+              작성 완료
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/form/AddEpigramForm.tsx
+++ b/src/components/form/AddEpigramForm.tsx
@@ -8,7 +8,7 @@ import { RadioItem } from '@/components/ui/radio/RadioItem';
 import TextArea from '@/components/ui/textarea';
 import { Pretendard } from '@/fonts';
 import { MakeEpigramFormSchema } from '@/apis/auth/schemas';
-import { MakeEpigramForm } from '@/types';
+import { MakeEpigramForm } from '@/apis/auth/types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';

--- a/src/components/ui/header/MainHeader.tsx
+++ b/src/components/ui/header/MainHeader.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 
 export default function MainHeader() {
   return (
-    <header className='border-b-line-100 fixed flex w-full items-center justify-between border-b-[1px] bg-white px-6 py-[13px] md:px-[72px] md:py-[17px] xl:px-[120px] xl:py-[22px]'>
+    <header className='border-b-line-100 fixed z-50 flex w-full items-center justify-between border-b-[1px] bg-white px-6 py-[13px] md:px-[72px] md:py-[17px] xl:px-[120px] xl:py-[22px]'>
       <div className='flex items-center justify-center gap-3 md:gap-6 xl:gap-9'>
         <Image src={menuIcon} alt='메뉴 아이콘' className='md:hidden'></Image>
         <Link href={'/'}>

--- a/src/components/ui/textarea/index.tsx
+++ b/src/components/ui/textarea/index.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/utils/cn';
 import { cva, VariantProps } from 'class-variance-authority';
 import { TextareaHTMLAttributes, useState, ChangeEvent, Ref } from 'react';
 
-const textAreaVariants = cva('bg-white placeholder-blue-300', {
+const textAreaVariants = cva('bg-white placeholder-blue-300 resize-none', {
   variants: {
     variant: {
       limit100: '',
@@ -17,10 +17,12 @@ const textAreaVariants = cva('bg-white placeholder-blue-300', {
       sm: 'w-[312px] h-[132px] pt-[10px] pb-[96px] px-[16px]',
       md: 'w-sm h-[132px] pt-[10px] pb-[96px] px-[16px]',
       lg: 'w-[640px] h-[148px] pt-[10px] pb-[106px] px-[16px]',
+      responsive: 'w-full h-[132px] pb-[90px] px-[16px] xl:h-[148px]',
     },
     fontSize: {
-      base: 'text-base',
-      xl: 'text-xl',
+      base: 'text-base placeholder:text-base',
+      xl: 'text-xl placeholder:text-xl',
+      responsive: 'text-base placeholder:text-base xl:text-xl xl:placeholder:text-xl',
     },
     border: {
       'line-border': 'border border-line-200 border-solid',
@@ -47,7 +49,7 @@ export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   ref?: Ref<HTMLTextAreaElement>;
 }
 
-export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ref, ...props }: TextAreaProps) {
+export default function TextArea({ variant, size, fontSize, border, borderRadius, maxLength, onChange, value, defaultValue, ref, className, ...props }: TextAreaProps) {
   const initialValue = value?.toString() || defaultValue?.toString() || '';
 
   const [charCount, setCharCount] = useState(initialValue.length);
@@ -84,7 +86,7 @@ export default function TextArea({ variant, size, fontSize, border, borderRadius
   return (
     <div className='relative'>
       <textarea
-        className={cn(textAreaVariants({ variant, size, fontSize, border, borderRadius }))}
+        className={cn(textAreaVariants({ variant, size, fontSize, border, borderRadius }), className)}
         onChange={handleChange}
         maxLength={effectiveMaxLength}
         value={value}

--- a/tests/addEpigramForm.test.tsx
+++ b/tests/addEpigramForm.test.tsx
@@ -1,0 +1,117 @@
+import AddEpigramForm from '@/components/form/AddEpigramForm';
+// import { MakeEpigramApiRequest } from '@/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+// const mockCreateEpigram = jest.fn();
+// jest.mock('@/에피그램 api 호출 경로', () => ({
+//   createEpigram: (data: MakeEpigramApiRequest) => mockCreateEpigram(data),
+// }));
+
+describe('AddEpigram Component', () => {
+  beforeEach(() => {
+    // mockCreateEpigram.mockClear();
+    render(<AddEpigramForm />);
+  });
+
+  test('에피그램 추가폼을 불러온다', () => {
+    expect(screen.getByText('에피그램 만들기')).toBeInTheDocument();
+
+    expect(screen.getByText('내용')).toBeInTheDocument();
+    expect(screen.getByText('저자')).toBeInTheDocument();
+    expect(screen.getByText('출처')).toBeInTheDocument();
+    expect(screen.getByText('태그')).toBeInTheDocument();
+
+    expect(screen.getByText('작성 완료')).toBeInTheDocument();
+  });
+
+  test('내용 필드가 비어있을 때 blur시 필수 입력 오류 메시지를 표시한다', async () => {
+    const contentInput = screen.getByPlaceholderText('500자 이내로 입력해주세요.');
+    fireEvent.focus(contentInput);
+    fireEvent.blur(contentInput);
+
+    expect(await screen.findByText('내용을 입력해주세요.')).toBeInTheDocument();
+  });
+
+  test('저자 필드가 비어있을 때 blur시 필수 입력 오류 메시지를 표시한다.', async () => {
+    const authorInput = screen.getByPlaceholderText('저자 이름 입력');
+    fireEvent.focus(authorInput);
+    fireEvent.blur(authorInput);
+
+    expect(await screen.findByText('저자 이름을 입력해주세요')).toBeInTheDocument();
+  });
+
+  test('저자 유형 변경에 따른 폼 변화를 확인한다', async () => {
+    const directAuthorOption = screen.getByLabelText('직접 입력');
+    const unknownAuthorOption = screen.getByLabelText('알 수 없음');
+    const selfAuthorOption = screen.getByLabelText('본인');
+
+    expect(directAuthorOption).toBeChecked();
+
+    expect(screen.getByPlaceholderText('저자 이름 입력')).toBeInTheDocument();
+
+    await userEvent.click(unknownAuthorOption);
+    expect(unknownAuthorOption).toBeChecked();
+    expect(screen.queryByPlaceholderText('저자 이름 입력')).not.toBeInTheDocument();
+
+    await userEvent.click(selfAuthorOption);
+    expect(selfAuthorOption).toBeChecked();
+    expect(screen.queryByPlaceholderText('저자 이름 입력')).not.toBeInTheDocument();
+
+    await userEvent.click(directAuthorOption);
+    expect(directAuthorOption).toBeChecked();
+    expect(screen.getByPlaceholderText('저자 이름 입력')).toBeInTheDocument();
+  });
+
+  test('태그가 3개를 초과하면 추가 버튼이 비활성화된다', async () => {
+    const tagInput = screen.getByPlaceholderText('입력하여 태그 작성 (최대 10자)');
+    const addTagButton = screen.getByText('추가');
+
+    await userEvent.type(tagInput, '태그1');
+    expect(addTagButton).not.toBeDisabled();
+    await userEvent.click(addTagButton);
+    expect(screen.getByText('태그1')).toBeInTheDocument();
+
+    await userEvent.type(tagInput, '태그2');
+    expect(addTagButton).not.toBeDisabled();
+    await userEvent.click(addTagButton);
+    expect(screen.getByText('태그2')).toBeInTheDocument();
+
+    await userEvent.type(tagInput, '태그3');
+    expect(addTagButton).not.toBeDisabled();
+    await userEvent.click(addTagButton);
+    expect(screen.getByText('태그3')).toBeInTheDocument();
+
+    expect(addTagButton).toBeDisabled();
+
+    expect(screen.getByText('태그는 최대 3개까지 추가할 수 있습니다')).toBeInTheDocument();
+  });
+
+  //원래는 필수입력요소인 내용, 저자만 있으면 통과이지만, 다른것도 다 넣어서 테스트 해봤습니다.
+  test('모든 유효성 검사가 통과하면 제출 버튼이 활성화된다', async () => {
+    const submitButton = screen.getByText('작성 완료');
+    expect(submitButton).toBeDisabled();
+
+    const contentInput = screen.getByPlaceholderText('500자 이내로 입력해주세요.');
+    const authorInput = screen.getByPlaceholderText('저자 이름 입력');
+    const sourceTitleInput = screen.getByPlaceholderText('출처 제목 입력');
+    const sourceUrlInput = screen.getByPlaceholderText('URL (ex. https://www.website.com/)');
+    const tagInput = screen.getByPlaceholderText('입력하여 태그 작성 (최대 10자)');
+    const addTagButton = screen.getByText('추가');
+
+    await userEvent.type(contentInput, '테스트 에피그램 내용');
+    await userEvent.type(authorInput, '테스트 저자');
+    await userEvent.type(sourceTitleInput, '테스트 출처');
+    await userEvent.type(sourceUrlInput, 'https://www.test.com');
+    await userEvent.type(tagInput, '테스트 태그1');
+    await userEvent.click(addTagButton);
+
+    expect(submitButton).not.toBeDisabled();
+  });
+});

--- a/tests/addEpigramForm.test.tsx
+++ b/tests/addEpigramForm.test.tsx
@@ -86,6 +86,8 @@ describe('AddEpigram Component', () => {
     await userEvent.type(tagInput, '태그3');
     expect(addTagButton).not.toBeDisabled();
     await userEvent.click(addTagButton);
+    const moreButton = screen.getByText(/\+1개 더보기/);
+    await userEvent.click(moreButton);
     expect(screen.getByText('태그3')).toBeInTheDocument();
 
     expect(addTagButton).toBeDisabled();


### PR DESCRIPTION
## ❓이슈
- close #60 

## :writing_hand: Description

에피그램 생성 페이지 작업 PR입니다.


에피그램 만들기 폼의 Validation은 TDD방식으로 구현했습니다.

우선 미흡한점은
1. textarea 컴포넌트에서 responsive속성을 size랑 fontSize에 줘서 해결했는데, 이거는 일단 재형님이 임시로 추가한 부분이 있어서 이 부분까지 머지 후 따로 이슈파서 미디어쿼리(반응형)부분 해결 예정입니다.
2. 재형님이 에피그램 수정파트부분 맡으셨는데 다른점이 조금 있어서 이것 역시 머지 후 같이 얘기나눠서 수정해보겠습니다. ("저자" 부분 radiobutton 눌렀을 때 반응 등)
3. 도균님께서 에피그램 관련 도메인 api를 작업중이라고 하셔서 이 부분 끝나면 onsubmit쪽에 Api 연결 예정입니다.


2번 예시를 보여드리면,
제꺼는 알수없음, 본인을 누르면 Input창이 없어지는데, 재형님꺼는 있는 것 같아서 얘기 후 수정해보겠습니다.
![image](https://github.com/user-attachments/assets/5a8ef5be-74a9-48cf-b2dc-c4f06bf76d6a)



테스트 코드 외 작업은
1. 에피그램 만들기 페이지 반응형으로 구현
2. 스키마, 타입정의 옮긴파일에 넣기
3. TextArea 컴포넌트 수정 후 적용
입니다.


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
