### PR TITLE
EP-69 rounded-button 확장성 개선 및 스타일 분리 작업

### DIFF
--- a/src/components/ui/buttons/roundedButton.tsx
+++ b/src/components/ui/buttons/roundedButton.tsx
@@ -1,51 +1,39 @@
-import React from 'react';
+import React, { ButtonHTMLAttributes, ReactNode } from 'react';
 import { cn } from '@/utils/cn';
+import { cva, VariantProps } from 'class-variance-authority';
 
-export interface RoundedButtonProps {
-  size?: 'small' | 'medium'; // 선택적 속성으로 변경
-  backgroundColor?: string;
-  borderColor?: string;
-  className?: string; // 커스텀 스타일 적용
-  disabled?: boolean; // 비활성화 여부
-  onClick: () => void;
-  children?: React.ReactNode;
+const buttonVariants = cva(
+  cn(
+    'flex items-center justify-center rounded-full border whitespace-nowrap transition hover:scale-105 hover:opacity-100',
+    'cursor-pointer',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    'bg-transparent',
+    'border-transparent',
+  ),
+  {
+    variants: {
+      size: {
+        sm: 'min-w-[76px] h-9 px-3 py-1', 
+        md: 'min-w-[102px] h-12 px-4 py-2',
+      },
+    },
+    defaultVariants: {
+      size: 'md', // 디폴트 값 
+    },
+  },
+);
+
+// 기본 button 속성들 확장
+export interface RoundedButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  children?: ReactNode;
 }
 
-const buttonSizes = {
-  small: { minWidth: '76px', height: '36px', padding: 'px-3 py-1' },
-  medium: { minWidth: '102px', height: '48px', padding: 'px-4 py-2' },
-};
-
-const RoundedButton: React.FC<RoundedButtonProps> = ({
-  size, // 선택적 속성
-  backgroundColor = 'transparent',
-  borderColor = 'transparent',
-  className,
-  disabled = false,
-  onClick,
-  children,
-}) => {
+function RoundedButton({ size, className, children, ...props }: RoundedButtonProps) {
   return (
-    <button
-      onClick={disabled ? undefined : onClick}
-      className={cn(
-        'flex items-center justify-center rounded-full border whitespace-nowrap transition hover:scale-105 hover:opacity-100',
-        'cursor-pointer',
-        disabled && 'cursor-not-allowed opacity-50',
-        size ? buttonSizes[size].padding : '', // size 없으면 기본 padding 제거
-        'gap-1', // 내부 간격 4px 유지
-        className, // 사용자 지정 스타일 적용
-      )}
-      style={{
-        borderColor,
-        backgroundColor,
-        ...(size ? buttonSizes[size] : {}), // size가 없으면 width, height 강제 적용 X
-      }}
-      disabled={disabled}
-    >
+    <button className={cn(buttonVariants({ size, className }))} {...props}>
       {children}
     </button>
   );
-};
+}
 
 export default RoundedButton;

--- a/src/components/ui/buttons/roundedButton.tsx
+++ b/src/components/ui/buttons/roundedButton.tsx
@@ -1,127 +1,49 @@
-import React from "react";
-import Image from "next/image";
-import { cn } from "@/utils/cn";
-import plus from "@/assets/icons/plus.svg";
-import like from "@/assets/icons/like.svg";
-import external from "@/assets/icons/external-link.svg";
+import React from 'react';
+import { cn } from '@/utils/cn';
 
 export interface RoundedButtonProps {
-  type: "더보기" | "에픽그램" | "좋아요버튼" | "왕도로가는길" | "커스텀";
-  size: "small" | "medium";
+  size?: 'small' | 'medium'; // 선택적 속성으로 변경
   backgroundColor?: string;
-  textColor?: string;
-  text?: string;
   borderColor?: string;
-  likeCount?: number;
+  className?: string; // 커스텀 스타일 적용
+  disabled?: boolean; // 비활성화 여부
   onClick: () => void;
+  children?: React.ReactNode;
 }
 
-interface PresetStyle {
-  backgroundColor: string;
-  text: string;
-  borderColor?: string;
-}
-
-const presetStyles: Record<Exclude<RoundedButtonProps["type"], "커스텀">, PresetStyle> = {
-  더보기: { backgroundColor: "transparent", text: "더보기", borderColor: "rgba(207, 219, 234, 1)" },
-  에픽그램: { backgroundColor: "transparent", text: "에픽그램 만들기", borderColor: "rgba(207, 219, 234, 1)" },
-  좋아요버튼: { backgroundColor: "black", text: "좋아요" },
-  왕도로가는길: { backgroundColor: "rgba(242, 242, 242, 1)", text: "왕도로 가는 길", borderColor: "rgba(242, 242, 242, 1)" },
-};
-
-const buttonSizes: Record<RoundedButtonProps["type"], Record<RoundedButtonProps["size"], { width?: string; height?: string; minWidth?: string }>> = {
-    더보기: {
-      small: { width: "101px", height: "48px" },
-      medium: { width: "120px", height: "56px" },
-    },
-    에픽그램: {
-      small: { width: "125px", height: "48px" },
-      medium: { width: "167px", height: "56px" },
-    },
-    좋아요버튼: {
-      small: { minWidth: "76px", height: "36px" },
-      medium: { minWidth: "102px", height: "48px" },
-    },
-    왕도로가는길: {
-      small: { minWidth: "140px", height: "48px" },
-      medium: { minWidth: "180px", height: "56px" },
-    },
-    커스텀: {
-      small: { width: "auto", height: "auto" }, 
-      medium: { width: "auto", height: "auto" },
-    },
-  };
-  
-
-const getTextStyle = (type: RoundedButtonProps["type"], size: RoundedButtonProps["size"], textColor?: string) => {
-  return cn(
-    "font-pretendard",
-    textColor ? `text-[${textColor}]` : "",
-    {
-      "text-sm font-normal text-blue-400": ["더보기", "에픽그램"].includes(type) && size === "small",
-      "text-xl font-normal text-blue-400": ["더보기", "에픽그램"].includes(type) && size === "medium",
-      "text-sm font-normal text-gray-300": type === "왕도로가는길" && size === "small",
-      "text-xl font-medium text-gray-300": type === "왕도로가는길" && size === "medium",
-      "text-sm font-normal leading-6 tracking-normal": size === "small",
-      "text-xl font-normal leading-8 tracking-normal": size === "medium",
-    }
-  );
+const buttonSizes = {
+  small: { minWidth: '76px', height: '36px', padding: 'px-3 py-1' },
+  medium: { minWidth: '102px', height: '48px', padding: 'px-4 py-2' },
 };
 
 const RoundedButton: React.FC<RoundedButtonProps> = ({
-  type,
-  size,
-  backgroundColor,
-  textColor,
-  text,
-  borderColor,
-  likeCount = 0,
+  size, // 선택적 속성
+  backgroundColor = 'transparent',
+  borderColor = 'transparent',
+  className,
+  disabled = false,
   onClick,
+  children,
 }) => {
-  const isCustom = type === "커스텀";
-  const buttonStyle = isCustom
-    ? { backgroundColor: backgroundColor || "transparent", text: text || "", borderColor: borderColor || "transparent" }
-    : presetStyles[type];
-
   return (
     <button
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       className={cn(
-        "flex items-center justify-center rounded-full border transition hover:opacity-100 hover:scale-105 whitespace-nowrap",
-        {
-          "bg-opacity-60 bg-black": type === "좋아요버튼",
-          "bg-black": buttonStyle.backgroundColor === "black",
-          "bg-white": buttonStyle.backgroundColor === "white",
-          "bg-transparent": buttonStyle.backgroundColor === "transparent",
-          "px-3 py-1": size === "small",
-          "px-4 py-2": size === "medium",
-          "gap-1": ["더보기", "에픽그램", "좋아요버튼"].includes(type), 
-          "gap-[5px]": type === "왕도로가는길" && size === "small", 
-          "gap-[6px]": type === "왕도로가는길" && size === "medium", 
-        }
+        'flex items-center justify-center rounded-full border whitespace-nowrap transition hover:scale-105 hover:opacity-100',
+        'cursor-pointer',
+        disabled && 'cursor-not-allowed opacity-50',
+        size ? buttonSizes[size].padding : '', // size 없으면 기본 padding 제거
+        'gap-1', // 내부 간격 4px 유지
+        className, // 사용자 지정 스타일 적용
       )}
       style={{
-        borderColor: buttonStyle.borderColor || "transparent",
-        borderWidth: ["더보기", "에픽그램"].includes(type) ? "1px" : undefined,
-        backgroundColor: isCustom ? backgroundColor : buttonStyle.backgroundColor,
-        ...(buttonSizes[type]?.[size] || {}),
+        borderColor,
+        backgroundColor,
+        ...(size ? buttonSizes[size] : {}), // size가 없으면 width, height 강제 적용 X
       }}
+      disabled={disabled}
     >
-      {type === "더보기" && <Image src={plus} alt="더보기 아이콘" width={24} height={24} />}
-
-      {type === "좋아요버튼" ? (
-        <>
-          <Image src={like} alt="좋아요 아이콘" width={size === "small" ? 20 : 36} height={size === "small" ? 20 : 36} />
-          <p className="font-pretendard font-semibold text-white">{likeCount}</p>
-        </>
-      ) : type === "왕도로가는길" ? (
-        <>
-          <p className={getTextStyle(type, size)}>{buttonStyle.text || text}</p>
-          <Image src={external} alt="외부 링크 아이콘" width={size === "small" ? 20 : 36} height={size === "small" ? 20 : 36} />
-        </>
-      ) : (
-        <p className={getTextStyle(type, size, textColor)}>{buttonStyle.text || text}</p>
-      )}
+      {children}
     </button>
   );
 };

--- a/src/components/ui/buttons/roundedButton.tsx
+++ b/src/components/ui/buttons/roundedButton.tsx
@@ -4,21 +4,29 @@ import { cva, VariantProps } from 'class-variance-authority';
 
 const buttonVariants = cva(
   cn(
-    'flex items-center justify-center rounded-full border whitespace-nowrap transition hover:scale-105 hover:opacity-100',
+    'flex items-center justify-center rounded-full whitespace-nowrap transition hover:scale-105 hover:opacity-100',
     'cursor-pointer',
-    'disabled:cursor-not-allowed disabled:opacity-50',
-    'bg-transparent',
-    'border-transparent',
+    'disabled:cursor-not-allowed disabled:opacity-80 disabled:hover:scale-100',
+    'text-md lg:text-xl',
   ),
   {
     variants: {
       size: {
-        sm: 'min-w-[76px] h-9 px-3 py-1', 
-        md: 'min-w-[102px] h-12 px-4 py-2',
+        sm: 'px-4 py-2',
+        md: 'px-6 py-2',
+        lg: 'px-8 py-4',
+        xl: 'px-10 py-5',
+      },
+      variant: {
+        default: 'bg-line-100 text-gray-300',
+        secondary: 'bg-black-600 text-blue-100',
+        tertiary: 'bg-blue-900 text-blue-100',
+        outline: 'border border-line-200 bg-transparent text-blue-500 font-medium',
       },
     },
     defaultVariants: {
-      size: 'md', // 디폴트 값 
+      size: 'md', // 디폴트 값
+      variant: 'default',
     },
   },
 );
@@ -28,9 +36,9 @@ export interface RoundedButtonProps extends ButtonHTMLAttributes<HTMLButtonEleme
   children?: ReactNode;
 }
 
-function RoundedButton({ size, className, children, ...props }: RoundedButtonProps) {
+function RoundedButton({ size, variant, className, children, ...props }: RoundedButtonProps) {
   return (
-    <button className={cn(buttonVariants({ size, className }))} {...props}>
+    <button className={cn(buttonVariants({ size, variant, className }))} {...props}>
       {children}
     </button>
   );

--- a/src/stories/buttons/roundedButton.stories.tsx
+++ b/src/stories/buttons/roundedButton.stories.tsx
@@ -7,54 +7,41 @@ import plus from '@/assets/icons/plus.svg';
 export default {
   title: 'Button/RoundedButton',
   component: RoundedButton,
-  decorators: [
-    (Story) => (
-      <div className='whitespace-nowrap'>
-        <Story />
-      </div>
-    ),
-  ],
   argTypes: {
     size: {
       control: 'select',
-      options: ['small', 'medium'],
+      options: ['sm', 'md'], 
     },
-    backgroundColor: { control: 'color' },
-    borderColor: { control: 'color' },
     disabled: { control: 'boolean' },
     className: { control: 'text' },
   },
 } as Meta<typeof RoundedButton>;
 
+
 const Template: StoryFn<RoundedButtonProps> = (args) => <RoundedButton {...args} />;
+
 
 export const Default = Template.bind({});
 Default.args = {
-  size: 'medium',
-  backgroundColor: 'transparent',
-  borderColor: 'rgba(207, 219, 234, 1)',
-  children: (
-    <>
-      <Image src={plus} alt='더보기 아이콘' width={24} height={24} />
-      텍스트
-    </>
-  ),
+  size: 'md',
+  children: '기본 버튼',
 };
+
 
 export const Disabled = Template.bind({});
 Disabled.args = {
-  size: 'medium',
-  backgroundColor: 'gray',
-  borderColor: 'gray',
+  size: 'md',
   disabled: true,
   children: '비활성화 버튼',
 };
 
-export const CustomHeight = Template.bind({}); // 사이즈 안 주고 커스텀 
-CustomHeight.args = {
-  backgroundColor: 'blue',
-  borderColor: 'blue',
-  className: 'h-[60px] w-[200px] text-xl font-bold', 
-  children: '커스텀 높이 버튼',
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  size: 'md',
+  children: (
+    <>
+      <Image src={plus} alt="더하기 아이콘" width={20} height={20} />
+      <span>추가</span> 
+    </>
+  ),
 };
-

--- a/src/stories/buttons/roundedButton.stories.tsx
+++ b/src/stories/buttons/roundedButton.stories.tsx
@@ -1,34 +1,28 @@
 import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import RoundedButton, { RoundedButtonProps } from '@/components/ui/buttons/roundedButton';
+import Image from 'next/image';
+import plus from '@/assets/icons/plus.svg';
 
 export default {
   title: 'Button/RoundedButton',
   component: RoundedButton,
   decorators: [
     (Story) => (
-      <div className="whitespace-nowrap">
+      <div className='whitespace-nowrap'>
         <Story />
       </div>
     ),
   ],
   argTypes: {
-    type: {
-      control: 'select',
-      options: ['더보기', '에픽그램', '좋아요버튼', '왕도로가는길', '커스텀'],
-    },
     size: {
       control: 'select',
       options: ['small', 'medium'],
     },
-    backgroundColor: {
-      control: 'color',
-      if: { arg: 'type', eq: '커스텀' },
-    },
-    text: {
-      control: 'text',
-      if: { arg: 'type', eq: '커스텀' },
-    },
+    backgroundColor: { control: 'color' },
+    borderColor: { control: 'color' },
+    disabled: { control: 'boolean' },
+    className: { control: 'text' },
   },
 } as Meta<typeof RoundedButton>;
 
@@ -36,14 +30,31 @@ const Template: StoryFn<RoundedButtonProps> = (args) => <RoundedButton {...args}
 
 export const Default = Template.bind({});
 Default.args = {
-  type: '더보기',
   size: 'medium',
+  backgroundColor: 'transparent',
+  borderColor: 'rgba(207, 219, 234, 1)',
+  children: (
+    <>
+      <Image src={plus} alt='더보기 아이콘' width={24} height={24} />
+      텍스트
+    </>
+  ),
 };
 
-export const Custom = Template.bind({});
-Custom.args = {
-  type: '커스텀',
+export const Disabled = Template.bind({});
+Disabled.args = {
   size: 'medium',
-  backgroundColor: 'blue',
-  text: '사용자 지정',
+  backgroundColor: 'gray',
+  borderColor: 'gray',
+  disabled: true,
+  children: '비활성화 버튼',
 };
+
+export const CustomHeight = Template.bind({}); // 사이즈 안 주고 커스텀 
+CustomHeight.args = {
+  backgroundColor: 'blue',
+  borderColor: 'blue',
+  className: 'h-[60px] w-[200px] text-xl font-bold', 
+  children: '커스텀 높이 버튼',
+};
+

--- a/src/stories/buttons/roundedButton.stories.tsx
+++ b/src/stories/buttons/roundedButton.stories.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import RoundedButton, { RoundedButtonProps } from '@/components/ui/buttons/roundedButton';
-import Image from 'next/image';
-import plus from '@/assets/icons/plus.svg';
 
 export default {
   title: 'Button/RoundedButton',
@@ -10,38 +8,69 @@ export default {
   argTypes: {
     size: {
       control: 'select',
-      options: ['sm', 'md'], 
+      options: ['sm', 'md', 'lg', 'xl'],
     },
-    disabled: { control: 'boolean' },
+    variant: {
+      control: 'select',
+      options: ['default', 'secondary', 'tertiary', 'outline'],
+    },
     className: { control: 'text' },
+    disabled: { control: 'boolean' },
   },
 } as Meta<typeof RoundedButton>;
 
-
 const Template: StoryFn<RoundedButtonProps> = (args) => <RoundedButton {...args} />;
 
-
+// 왕도로 가는길은 Default 사용
 export const Default = Template.bind({});
 Default.args = {
   size: 'md',
+  variant: 'default',
   children: '기본 버튼',
 };
 
+// 좋아요 버튼은 secondary 사용
+export const Secondary = Template.bind({});
+Secondary.args = {
+  size: 'md',
+  variant: 'secondary',
+  children: 'Secondary 버튼',
+};
+
+// 에픽그램 만들기 버튼은 tertiary
+export const Tertiary = Template.bind({});
+Tertiary.args = {
+  size: 'md',
+  variant: 'tertiary',
+  children: 'Tertiary 버튼',
+};
+
+// 더보기, 에픽그램 및 댓글추가 Outline
+export const Outline = Template.bind({});
+Outline.args = {
+  size: 'md',
+  variant: 'outline',
+  children: 'Outline 버튼',
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  size: 'lg',
+  variant: 'default',
+  children: 'Large 버튼',
+};
+
+export const ExtraLarge = Template.bind({});
+ExtraLarge.args = {
+  size: 'xl',
+  variant: 'default',
+  children: 'XL 버튼',
+};
 
 export const Disabled = Template.bind({});
 Disabled.args = {
   size: 'md',
+  variant: 'default',
   disabled: true,
   children: '비활성화 버튼',
-};
-
-export const WithIcon = Template.bind({});
-WithIcon.args = {
-  size: 'md',
-  children: (
-    <>
-      <Image src={plus} alt="더하기 아이콘" width={20} height={20} />
-      <span>추가</span> 
-    </>
-  ),
 };


### PR DESCRIPTION
## ❓이슈
- close #94 

## :writing_hand: Description

기존 코드에 있던 내용을 다 지우고 
성락님이 말씀 주셨던 것 처럼 

1. className을 props로 받아서 수정 가능하도록 변경 했습니다. 

2. 텍스트는 children으로 전달해서 유연하게 사용할 수 있도록 했습니다. 

3. 아이콘 같은 경우는 props로 주기 어려우므로 children을 사용하도록 개선했습니다. 

4. cursor-pointer도 button에 적용 (도균님 피드백)

5. disabled일 땐 not-allow로 적용 (도균님 피드백)

-------------------------------------------------

- ButtonHTMLAttributes를 사용하여 기본 버튼 속성들을 자동으로 받을 수 있게 수정함.

- cva 함수를 이용해서 한 번에 묶어서 정의함. 

- 사용법: className으로 커스텀 해서 사용하시면 됩니다. 




<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
