### PR TITLE
EP-55 오늘의 감정 컴포넌트 구현(메인페이지)

### DIFF
--- a/src/apis/emotion-log/index.ts
+++ b/src/apis/emotion-log/index.ts
@@ -1,16 +1,16 @@
-import axiosClientHelper from "@/utils/network/axiosClientHelper"
-import {  EmotionRequset, GetMonthlyEmotionLogs, TodayEmotionLogs } from "./types"
-import { safeResponse } from "@/utils/network/safeResponse"
-import { monthlyEmotionLogsSchema, todayEmotionLogsSchema } from "./schemas"
+import axiosClientHelper from '@/utils/network/axiosClientHelper';
+import { EmotionRequset, GetMonthlyEmotionLogs, TodayEmotionLogs } from './types';
+import { safeResponse } from '@/utils/network/safeResponse';
+import { monthlyEmotionLogsSchema, todayEmotionLogsSchema } from './schemas';
 
 /**
  * 오늘의 감정 저장
  * https://fe-project-epigram-api.vercel.app/docs/#/emotionLogs/today
  */
 
-export const postTodayEmotionLog = async (params : EmotionRequset) => {
-    const response = await axiosClientHelper.post<TodayEmotionLogs>('/emotionLogs/today', { ...params })
-    return safeResponse(response.data, todayEmotionLogsSchema)
+export const postTodayEmotionLog = async (params: EmotionRequset) => {
+  const response = await axiosClientHelper.post<TodayEmotionLogs>('/emotionLogs/today', { ...params });
+  return safeResponse(response.data, todayEmotionLogsSchema);
 };
 
 /**
@@ -18,22 +18,24 @@ export const postTodayEmotionLog = async (params : EmotionRequset) => {
  * https://fe-project-epigram-api.vercel.app/docs/#/emotionLogs/today
  */
 
-export const getTodayEmotionLog = async (userId : number) => {
-    const response = await axiosClientHelper.get<TodayEmotionLogs>('/emotionLogs/today', {
-        params : {userId},
-    })
-    return safeResponse(response.data, todayEmotionLogsSchema)
-}
+export const getTodayEmotionLog = async (userId: number) => {
+  const response = await axiosClientHelper.get<TodayEmotionLogs>('/emotionLogs/today', {
+    params: { userId },
+  });
+  if (response.status === 204) {
+    return null;
+  }
+  return safeResponse(response.data, todayEmotionLogsSchema);
+};
 
 /**
  * 월별 감정 조회
  * https://fe-project-epigram-api.vercel.app/docs/#/emotionLogs/monthly
  */
 
-
-export const getMonthlyEmotionLogs = async (monthlyEmotionLogsParams : GetMonthlyEmotionLogs) => {
-    const response = await axiosClientHelper.get<GetMonthlyEmotionLogs>('/emotionLogs/monthly', {
-        params : monthlyEmotionLogsParams
-    })
-    return safeResponse(response.data, monthlyEmotionLogsSchema)
-}
+export const getMonthlyEmotionLogs = async (monthlyEmotionLogsParams: GetMonthlyEmotionLogs) => {
+  const response = await axiosClientHelper.get<GetMonthlyEmotionLogs>('/emotionLogs/monthly', {
+    params: monthlyEmotionLogsParams,
+  });
+  return safeResponse(response.data, monthlyEmotionLogsSchema);
+};

--- a/src/apis/emotion-log/queries.tsx
+++ b/src/apis/emotion-log/queries.tsx
@@ -1,15 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getMonthlyEmotionLogs, getTodayEmotionLog, postTodayEmotionLog } from '.';
 import { EmotionRequset, GetMonthlyEmotionLogs, TodayEmotionLogs } from './types';
-import { User } from '@/apis/user/types';
+import { getUser } from '@/apis/user';
 
-export const useGetTodayEmotionLog = (userId: User['id']) => {
+export const useGetTodayEmotionLog = () => {
   return useQuery({
-    queryKey: ['todayEmotionLog', userId],
-    queryFn: () => getTodayEmotionLog(userId),
+    queryKey: ['todayEmotionLog'],
+    queryFn: async () => {
+      const user = await getUser();
+      return await getTodayEmotionLog(user.id);
+    },
   });
 };
-
 export const usePostTodayEmotionLog = () => {
   const queryClient = useQueryClient();
 
@@ -34,14 +36,14 @@ export const useOptimisticEmotionLog = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ params }: { params: EmotionRequset; userId: User['id'] }) => {
+    mutationFn: (params: EmotionRequset) => {
       return postTodayEmotionLog(params);
     },
-    onMutate: async ({ params, userId }: { params: EmotionRequset; userId: User['id'] }) => {
-      const previousData: TodayEmotionLogs = queryClient.getQueryData(['todayEmotionLog', userId])!;
+    onMutate: async (params: EmotionRequset) => {
+      const previousData: TodayEmotionLogs = queryClient.getQueryData(['todayEmotionLog'])!;
       await queryClient.cancelQueries({ queryKey: ['todayEmotionLog'] });
 
-      queryClient.setQueryData(['todayEmotionLog', userId], {
+      queryClient.setQueryData(['todayEmotionLog'], {
         ...previousData,
         emotion: params.emotion,
       });

--- a/src/apis/emotion-log/queries.tsx
+++ b/src/apis/emotion-log/queries.tsx
@@ -1,31 +1,59 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { getMonthlyEmotionLogs, getTodayEmotionLog, postTodayEmotionLog } from "."
-import { EmotionRequset,  GetMonthlyEmotionLogs } from "./types"
-import { User } from "../user/types"
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getMonthlyEmotionLogs, getTodayEmotionLog, postTodayEmotionLog } from '.';
+import { EmotionRequset, GetMonthlyEmotionLogs, TodayEmotionLogs } from './types';
+import { User } from '@/apis/user/types';
 
-export const useGetTodayEmotionLog = (userId : User['id']) => {
-    return useQuery({
-        queryKey : [ 'todayEmotionLog' ,userId ],
-        queryFn :  () => getTodayEmotionLog(userId),
-    })
-}
+export const useGetTodayEmotionLog = (userId: User['id']) => {
+  return useQuery({
+    queryKey: ['todayEmotionLog', userId],
+    queryFn: () => getTodayEmotionLog(userId),
+  });
+};
 
 export const usePostTodayEmotionLog = () => {
-    const queryClient = useQueryClient()
+  const queryClient = useQueryClient();
 
-    return useMutation({
-        mutationFn : (params : EmotionRequset) => {
-            return postTodayEmotionLog(params)
-        },
-        onSuccess : () => {
-            queryClient.invalidateQueries({ queryKey : ['todayEmotionLog']})
-        }
-    })
-}
+  return useMutation({
+    mutationFn: (params: EmotionRequset) => {
+      return postTodayEmotionLog(params);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todayEmotionLog'] });
+    },
+  });
+};
 
-export const useGetMonthlyEmotionLogs = (params : GetMonthlyEmotionLogs) => {
-    return useQuery({
-        queryKey : ['month', params],
-        queryFn : () => getMonthlyEmotionLogs(params),
-    })
-}
+export const useGetMonthlyEmotionLogs = (params: GetMonthlyEmotionLogs) => {
+  return useQuery({
+    queryKey: ['month', params],
+    queryFn: () => getMonthlyEmotionLogs(params),
+  });
+};
+
+export const useOptimisticEmotionLog = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ params }: { params: EmotionRequset; userId: User['id'] }) => {
+      return postTodayEmotionLog(params);
+    },
+    onMutate: async ({ params, userId }: { params: EmotionRequset; userId: User['id'] }) => {
+      const previousData: TodayEmotionLogs = queryClient.getQueryData(['todayEmotionLog', userId])!;
+      await queryClient.cancelQueries({ queryKey: ['todayEmotionLog'] });
+
+      queryClient.setQueryData(['todayEmotionLog', userId], {
+        ...previousData,
+        emotion: params.emotion,
+      });
+      return previousData;
+    },
+    onError: (error, variables, context) => {
+      if (context) {
+        queryClient.setQueryData(['todayEmotionLog'], context);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['todayEmotionLog'] });
+    },
+  });
+};

--- a/src/apis/emotion-log/schemas.ts
+++ b/src/apis/emotion-log/schemas.ts
@@ -1,29 +1,29 @@
-import { z } from "zod";
+import { z } from 'zod';
 
-export const emotionEnum = z.enum(['MOVED', 'HAPPY', 'WORRIED', 'SAD', 'ANGRY'])
+export const emotionEnum = z.enum(['MOVED', 'HAPPY', 'WORRIED', 'SAD', 'ANGRY']);
 
 export const monthlyEmotionLogsSchema = z.array(
-    z.object({
-    createdAt : z.string(),
-    emotion : emotionEnum,
-    userId : z.number(),
-    id : z.number(),
-})
-)
+  z.object({
+    createdAt: z.string(),
+    emotion: emotionEnum,
+    userId: z.number(),
+    id: z.number(),
+  }),
+);
 
 export const todayEmotionLogsSchema = z.object({
-    createdAt : z.string(),
-    emotion : emotionEnum,
-    userId : z.number(),
-    id : z.number(),
-})
+  createdAt: z.string(),
+  emotion: emotionEnum,
+  userId: z.number(),
+  id: z.number(),
+});
 
 export const getMonthlyEmotionLogsSchema = z.object({
-    userId : z.number(),
-    year : z.number(),
-    month : z.number()
-})
+  userId: z.number(),
+  year: z.number(),
+  month: z.number(),
+});
 
 export const emotionRequest = z.object({
-    emotion : emotionEnum
-})
+  emotion: emotionEnum,
+});

--- a/src/app/api/[...endpoint]/route.ts
+++ b/src/app/api/[...endpoint]/route.ts
@@ -17,7 +17,7 @@ export const GET = async (request: NextRequest) => {
           }
         : {},
     );
-    return NextResponse.json(apiResponse.data, { status: apiResponse.status });
+    return apiResponse.data ? NextResponse.json(apiResponse.data, { status: apiResponse.status }) : new NextResponse(null, { status: apiResponse.status });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/components/epigrams/DailyEmotion.tsx
+++ b/src/components/epigrams/DailyEmotion.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { AnimatePresence, motion } from 'motion/react';
+import { EMOTION_STATUS, EMOTION_STATUS_KR } from '@/constants/emotions';
+import EmotionButton from '@/components/ui/emotionButton';
+
+export default function DailyEmotion() {
+  return (
+    <section className='flex flex-col gap-4 md:gap-8'>
+      <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>오늘의 감정은 어떤가요?</h2>
+      <AnimatePresence>
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className='flex justify-center gap-4'>
+          {EMOTION_STATUS.map((emotion, index) => (
+            <motion.div key={index} animate={{ opacity: 1 }} transition={{ duration: 0.2 }} whileHover={{ y: -8, transition: { duration: 0.2 } }} className='flex flex-col items-center gap-2'>
+              <EmotionButton emotion={emotion} isInteractive />
+              <span className='text-sub-blue-1 lg:text-2lg text-sm font-semibold md:text-lg'>{EMOTION_STATUS_KR[index]}</span>
+            </motion.div>
+          ))}
+        </motion.div>
+      </AnimatePresence>
+    </section>
+  );
+}

--- a/src/components/epigrams/DailyEmotion.tsx
+++ b/src/components/epigrams/DailyEmotion.tsx
@@ -3,20 +3,42 @@
 import { AnimatePresence, motion } from 'motion/react';
 import { EMOTION_STATUS, EMOTION_STATUS_KR } from '@/constants/emotions';
 import EmotionButton from '@/components/ui/emotionButton';
+import { useGetTodayEmotionLog, useOptimisticEmotionLog } from '@/apis/emotion-log/queries';
+import { Emotion } from '@/apis/emotion-log/types';
+import { useGetUser } from '@/apis/user/queries';
+import { useEffect } from 'react';
 
 export default function DailyEmotion() {
+  const { mutateAsync: updateEmotionLog } = useOptimisticEmotionLog();
+  const { data: user } = useGetUser();
+  const { data: dailyEmotion, refetch, isFetching } = useGetTodayEmotionLog(user?.id ?? 0);
+
+  useEffect(() => {
+    if (user) {
+      refetch();
+    }
+  }, [user, refetch]);
+
+  const handleEmotionClick = (emotion: Emotion) => {
+    if (user) updateEmotionLog({ params: { emotion }, userId: user.id });
+  };
+
   return (
     <section className='flex flex-col gap-4 md:gap-8'>
-      <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>오늘의 감정은 어떤가요?</h2>
       <AnimatePresence>
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className='flex justify-center gap-4'>
-          {EMOTION_STATUS.map((emotion, index) => (
-            <motion.div key={index} animate={{ opacity: 1 }} transition={{ duration: 0.2 }} whileHover={{ y: -8, transition: { duration: 0.2 } }} className='flex flex-col items-center gap-2'>
-              <EmotionButton emotion={emotion} isInteractive />
-              <span className='text-sub-blue-1 lg:text-2lg text-sm font-semibold md:text-lg'>{EMOTION_STATUS_KR[index]}</span>
-            </motion.div>
-          ))}
-        </motion.div>
+        {user && !isFetching && !dailyEmotion && (
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0, transition: { duration: 1 } }} className='flex flex-col items-center gap-4'>
+            <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>오늘의 감정은 어떤가요?</h2>
+            <div className='flex justify-center gap-4'>
+              {EMOTION_STATUS.map((emotion, index) => (
+                <motion.div key={index} animate={{ opacity: 1 }} transition={{ duration: 0.2 }} whileHover={{ y: -8, transition: { duration: 0.2 } }} className='flex flex-col items-center gap-2'>
+                  <EmotionButton emotion={emotion} isInteractive onClick={() => handleEmotionClick(emotion)} />
+                  <span className='text-sub-blue-1 lg:text-2lg text-sm font-semibold md:text-lg'>{EMOTION_STATUS_KR[index]}</span>
+                </motion.div>
+              ))}
+            </div>
+          </motion.div>
+        )}
       </AnimatePresence>
     </section>
   );

--- a/src/components/epigrams/DailyEmotion.tsx
+++ b/src/components/epigrams/DailyEmotion.tsx
@@ -5,34 +5,29 @@ import { EMOTION_STATUS, EMOTION_STATUS_KR } from '@/constants/emotions';
 import EmotionButton from '@/components/ui/emotionButton';
 import { useGetTodayEmotionLog, useOptimisticEmotionLog } from '@/apis/emotion-log/queries';
 import { Emotion } from '@/apis/emotion-log/types';
-import { useGetUser } from '@/apis/user/queries';
-import { useEffect } from 'react';
+import { useState } from 'react';
 
 export default function DailyEmotion() {
   const { mutateAsync: updateEmotionLog } = useOptimisticEmotionLog();
-  const { data: user } = useGetUser();
-  const { data: dailyEmotion, refetch, isFetching } = useGetTodayEmotionLog(user?.id ?? 0);
+  const { data: dailyEmotion, isFetching } = useGetTodayEmotionLog();
+  const [isPosting, setIsPosting] = useState(false);
 
-  useEffect(() => {
-    if (user) {
-      refetch();
-    }
-  }, [user, refetch]);
-
-  const handleEmotionClick = (emotion: Emotion) => {
-    if (user) updateEmotionLog({ params: { emotion }, userId: user.id });
+  const handleEmotionClick = async (emotion: Emotion) => {
+    setIsPosting(true);
+    await updateEmotionLog({ emotion });
+    setIsPosting(false);
   };
 
   return (
     <section className='flex flex-col gap-4 md:gap-8'>
       <AnimatePresence>
-        {user && !isFetching && !dailyEmotion && (
+        {!isFetching && !dailyEmotion && (
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0, transition: { duration: 1 } }} className='flex flex-col items-center gap-4'>
             <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>오늘의 감정은 어떤가요?</h2>
             <div className='flex justify-center gap-4'>
               {EMOTION_STATUS.map((emotion, index) => (
                 <motion.div key={index} animate={{ opacity: 1 }} transition={{ duration: 0.2 }} whileHover={{ y: -8, transition: { duration: 0.2 } }} className='flex flex-col items-center gap-2'>
-                  <EmotionButton emotion={emotion} isInteractive onClick={() => handleEmotionClick(emotion)} />
+                  <EmotionButton emotion={emotion} isInteractive onClick={() => handleEmotionClick(emotion)} disabled={isPosting} />
                   <span className='text-sub-blue-1 lg:text-2lg text-sm font-semibold md:text-lg'>{EMOTION_STATUS_KR[index]}</span>
                 </motion.div>
               ))}

--- a/src/components/ui/emotionButton/index.tsx
+++ b/src/components/ui/emotionButton/index.tsx
@@ -36,12 +36,13 @@ const buttonBorderMap = {
 interface EmotionButtonProps {
   buttonVariant?: boolean;
   size?: 'sm' | 'md' | 'lg' | 'xl';
+  isInteractive?: boolean;
   emotion: EmotionType;
   emotionVariant?: EmotionProps['variant'];
   onClick?: () => void;
 }
 
-export default function EmotionButton({ buttonVariant, emotion, emotionVariant, size, onClick }: EmotionButtonProps) {
+export default function EmotionButton({ buttonVariant, emotion, emotionVariant, size, onClick, isInteractive }: EmotionButtonProps) {
   const [currentButtonVariant, setCurrentButtonVariant] = useState(buttonVariant);
 
   const buttonBorderColor = buttonBorderMap[emotion];
@@ -51,8 +52,8 @@ export default function EmotionButton({ buttonVariant, emotion, emotionVariant, 
     onClick?.();
   };
   return (
-    <button className={cn(buttonStyles({ isActive: currentButtonVariant, size }), buttonBorderColor)} onClick={handleClick}>
-      <Emotion variant={emotionVariant} emotion={emotion} size={size} />
+    <button className={cn(buttonStyles({ isActive: currentButtonVariant, size }), buttonBorderColor, isInteractive && 'size-12 md:size-16 lg:size-20 xl:size-24')} onClick={handleClick}>
+      <Emotion variant={emotionVariant} emotion={emotion} size={size} className={cn(isInteractive && 'size-8 sm:size-9 md:size-10 lg:size-11 xl:size-12')} />
     </button>
   );
 }

--- a/src/components/ui/emotionButton/index.tsx
+++ b/src/components/ui/emotionButton/index.tsx
@@ -40,9 +40,10 @@ interface EmotionButtonProps {
   emotion: EmotionType;
   emotionVariant?: EmotionProps['variant'];
   onClick?: () => void;
+  disabled?: boolean;
 }
 
-export default function EmotionButton({ buttonVariant, emotion, emotionVariant, size, onClick, isInteractive }: EmotionButtonProps) {
+export default function EmotionButton({ buttonVariant, emotion, emotionVariant, size, onClick, isInteractive, disabled = false }: EmotionButtonProps) {
   const [currentButtonVariant, setCurrentButtonVariant] = useState(buttonVariant);
 
   const buttonBorderColor = buttonBorderMap[emotion];
@@ -52,7 +53,11 @@ export default function EmotionButton({ buttonVariant, emotion, emotionVariant, 
     onClick?.();
   };
   return (
-    <button className={cn(buttonStyles({ isActive: currentButtonVariant, size }), buttonBorderColor, isInteractive && 'size-12 md:size-16 lg:size-20 xl:size-24')} onClick={handleClick}>
+    <button
+      className={cn(buttonStyles({ isActive: currentButtonVariant, size }), buttonBorderColor, isInteractive && 'size-12 md:size-16 lg:size-20 xl:size-24')}
+      onClick={handleClick}
+      disabled={disabled}
+    >
       <Emotion variant={emotionVariant} emotion={emotion} size={size} className={cn(isInteractive && 'size-8 sm:size-9 md:size-10 lg:size-11 xl:size-12')} />
     </button>
   );

--- a/src/constants/emotions.ts
+++ b/src/constants/emotions.ts
@@ -1,1 +1,3 @@
-export const EMOTION_STATUS = ['MOVED', 'HAPPY', 'SAD', 'WORRIED', 'ANGRY'] as const;
+export const EMOTION_STATUS = ['MOVED', 'HAPPY', 'WORRIED', 'SAD', 'ANGRY'] as const;
+
+export const EMOTION_STATUS_KR = ['감동', '기쁨', '고민', '슬픔', '분노'] as const;


### PR DESCRIPTION
## ❓이슈
- close #66 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

오늘의 감정 컴포넌트 구현에 관한 PR입니다.

로그인한 사용자가 오늘 이미 감정을 선택했다면 컴포넌트가 보이지 않도록 구현했습니다.

또한, 감정 선택 후 사라지는 애니메이션도 넣었으며, 즉각적으로 컴포넌트가 사라지도록 구현하기 위해 낙관적 업데이트로 구현했습니다.

낙관적 업데이트 때문에 기존 emotion-log 쿼리 파일에서 훅 하나 추가했습니다.

사용자 조회 후 받은 id값으로 오늘의 감정을 조회해야해서 초기 id값을 0으로 부여했고, refetch는 useEffect로 처리했습니다.

### 추가로, 오늘의 감정 조회 api에서 오늘 감정을 선택하지 않았다면 204로 응답하는데, 이 응답에서 response가 없습니다. 이를 처리하기 위해 기존 api 파일에서 204 상태코드에 대한 return을 추가했습니다.

### route handler에 get 메소드도 빈 값 처리하기 위해 로직 수정했습니다.


![image](https://github.com/user-attachments/assets/135a7878-feb7-46a4-ad9f-fd5857881ca0)


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
