### PR TITLE
EP-68 에피그램 리스트 컴포넌트 구현(메인페이지)

### DIFF
--- a/src/app/(after-login)/epigrams/page.tsx
+++ b/src/app/(after-login)/epigrams/page.tsx
@@ -1,3 +1,15 @@
+import EpigramList from '@/components/epigrams/EpigramList';
+import MainHeader from '@/components/ui/header/MainHeader';
+
 export default function Epigrams() {
-  return <div>에피그램 페이지</div>;
+  return (
+    <>
+      <MainHeader />
+      <main className='bg-background-100 mt-16 flex min-h-[calc(100dvh-4rem)] flex-col items-center gap-16 pt-6 pb-20'>
+        <div className='w-[312px] sm:w-[384px] md:w-[640px]'>
+          <EpigramList />
+        </div>
+      </main>
+    </>
+  );
 }

--- a/src/app/(after-login)/epigrams/page.tsx
+++ b/src/app/(after-login)/epigrams/page.tsx
@@ -1,4 +1,3 @@
-import EpigramList from '@/components/epigrams/EpigramList';
 import MainHeader from '@/components/ui/header/MainHeader';
 
 export default function Epigrams() {
@@ -6,9 +5,7 @@ export default function Epigrams() {
     <>
       <MainHeader />
       <main className='bg-background-100 mt-16 flex min-h-[calc(100dvh-4rem)] flex-col items-center gap-16 pt-6 pb-20'>
-        <div className='w-[312px] sm:w-[384px] md:w-[640px]'>
-          <EpigramList />
-        </div>
+        <div className='w-[312px] space-y-16 sm:w-[384px] md:w-[640px] md:space-y-20'></div>
       </main>
     </>
   );

--- a/src/components/epigrams/DailyEpigram.tsx
+++ b/src/components/epigrams/DailyEpigram.tsx
@@ -1,5 +1,7 @@
 import { Epigram } from '@/apis/epigram/types';
 import TextCard from '@/components/ui/textcard';
+import * as motion from 'motion/react-client';
+import Link from 'next/link';
 
 const REVALIDATE_TIME = 60 * 10;
 
@@ -13,9 +15,13 @@ export default async function DailyEpigram() {
   const epigramData: Epigram = await response.json();
 
   return (
-    <div className='flex flex-col gap-6 text-lg md:text-2xl'>
-      <h2 className='text-black-600 font-semibold'>오늘의 에피그램</h2>
-      <TextCard cardContent={epigramData.content} author={epigramData.author} tags={epigramData.tags} />
-    </div>
+    <section className='flex flex-col gap-4 md:gap-8'>
+      <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>오늘의 에피그램</h2>
+      <motion.div exit={{ opacity: 0, y: -10 }} initial={{ opacity: 1, y: 0 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }} whileHover={{ y: -8, transition: { duration: 0.2 } }}>
+        <Link href={`/epigrams/${epigramData.id}`} className='text-md cursor-pointer md:text-lg lg:text-xl xl:text-2xl'>
+          <TextCard cardContent={epigramData.content} author={epigramData.author} tags={epigramData.tags} />
+        </Link>
+      </motion.div>
+    </section>
   );
 }

--- a/src/components/epigrams/EpigramList.tsx
+++ b/src/components/epigrams/EpigramList.tsx
@@ -9,6 +9,7 @@ import RoundedButton from '@/components/ui/buttons/roundedButton';
 import { isEmpty } from 'es-toolkit/compat';
 import Image from 'next/image';
 import EmptyEpigram from '@/assets/images/empty_epigram.svg';
+import PlusIcon from '@/assets/icons/plus.svg';
 
 const PAGE_LIMIT = 3;
 
@@ -59,7 +60,10 @@ export default function EpigramList() {
 
           {hasNextPage && totalCount > epigrams.length && (
             <div className='flex w-full justify-center'>
-              <RoundedButton type='에픽그램' size='small' onClick={handleClick} />
+              <RoundedButton onClick={handleClick} variant='outline' className='gap-2'>
+                <Image src={PlusIcon} alt='에피그램 더보기' />
+                에피그램 더보기
+              </RoundedButton>
             </div>
           )}
         </div>

--- a/src/components/epigrams/EpigramList.tsx
+++ b/src/components/epigrams/EpigramList.tsx
@@ -24,10 +24,10 @@ export default function EpigramList() {
   };
 
   return (
-    <section className='flex flex-col gap-2'>
+    <section className='flex flex-col gap-4 md:gap-8'>
       <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>최신 에피그램</h2>
       <AnimatePresence>
-        <div className='flex flex-col gap-10'>
+        <div className='flex flex-col gap-8 md:gap-14 xl:gap-16'>
           {isLoading && (
             <>
               <MainEpigramSkeletonList count={PAGE_LIMIT} />
@@ -47,7 +47,7 @@ export default function EpigramList() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.5 }}
                 whileHover={{ y: -8, transition: { duration: 0.2 } }}
-                className='cursor-pointer'
+                className='text-md cursor-pointer md:text-lg lg:text-xl xl:text-2xl'
                 href={`/epigrams/${epigram.id}`}
               >
                 <TextCard author={epigram.author} cardContent={epigram.content} tags={epigram.tags} />

--- a/src/components/epigrams/EpigramList.tsx
+++ b/src/components/epigrams/EpigramList.tsx
@@ -15,6 +15,14 @@ const PAGE_LIMIT = 3;
 
 const MotionLink = motion.create(Link);
 
+const epigramListAnimation = {
+  exit: { opacity: 0, y: -10 },
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.5 },
+  whileHover: { y: -8, transition: { duration: 0.2 } },
+};
+
 export default function EpigramList() {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useGetEpigrams({ limit: PAGE_LIMIT });
   const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
@@ -43,13 +51,14 @@ export default function EpigramList() {
             epigrams.map((epigram) => (
               <MotionLink
                 key={epigram.id}
-                exit={{ opacity: 0, y: -10 }}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-                whileHover={{ y: -8, transition: { duration: 0.2 } }}
+                variants={epigramListAnimation}
                 className='text-md cursor-pointer md:text-lg lg:text-xl xl:text-2xl'
                 href={`/epigrams/${epigram.id}`}
+                initial='initial'
+                whileInView='animate'
+                whileHover='whileHover'
+                exit='exit'
+                transition={epigramListAnimation.transition}
               >
                 <TextCard author={epigram.author} cardContent={epigram.content} tags={epigram.tags} />
               </MotionLink>

--- a/src/components/epigrams/EpigramList.tsx
+++ b/src/components/epigrams/EpigramList.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { AnimatePresence, motion } from 'motion/react';
+import { useGetEpigrams } from '@/apis/epigram/queries';
+import { MainEpigramButtonSkeleton, MainEpigramSkeletonList } from '@/components/ui/skeletons/EpigramCardSkeleton';
+import TextCard from '@/components/ui/textcard';
+import RoundedButton from '@/components/ui/buttons/roundedButton';
+import { isEmpty } from 'es-toolkit/compat';
+import Image from 'next/image';
+import EmptyEpigram from '@/assets/images/empty_epigram.svg';
+
+const PAGE_LIMIT = 3;
+
+const MotionLink = motion.create(Link);
+
+export default function EpigramList() {
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useGetEpigrams({ limit: PAGE_LIMIT });
+  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
+  const totalCount = data?.pages.flatMap((page) => page.totalCount)[0] ?? 0;
+
+  const handleClick = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  return (
+    <section className='flex flex-col gap-2'>
+      <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>최신 에피그램</h2>
+      <AnimatePresence>
+        <div className='flex flex-col gap-10'>
+          {isLoading && (
+            <>
+              <MainEpigramSkeletonList count={PAGE_LIMIT} />
+              <MainEpigramButtonSkeleton />
+            </>
+          )}
+
+          {/* 로딩 종료 후 empty 상태 조건부 렌더링 */}
+          {!isLoading && isEmpty(epigrams) ? (
+            <Empty />
+          ) : (
+            epigrams.map((epigram) => (
+              <MotionLink
+                key={epigram.id}
+                exit={{ opacity: 0, y: -10 }}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5 }}
+                whileHover={{ y: -8, transition: { duration: 0.2 } }}
+                className='cursor-pointer'
+                href={`/epigrams/${epigram.id}`}
+              >
+                <TextCard author={epigram.author} cardContent={epigram.content} tags={epigram.tags} />
+              </MotionLink>
+            ))
+          )}
+
+          {isFetchingNextPage && <MainEpigramSkeletonList count={PAGE_LIMIT} />}
+
+          {hasNextPage && totalCount > epigrams.length && (
+            <div className='flex w-full justify-center'>
+              <RoundedButton type='에픽그램' size='small' onClick={handleClick} />
+            </div>
+          )}
+        </div>
+      </AnimatePresence>
+    </section>
+  );
+}
+
+function Empty() {
+  return (
+    <motion.div exit={{ opacity: 0, y: -10 }} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }} className='flex flex-col items-center gap-4'>
+      <Image src={EmptyEpigram} alt='빈 에피그램 리스트' width={96} height={96} />
+      <p className='text-md from-black-700 via-black-400 to-black-200 flex flex-col items-center gap-2 bg-gradient-to-r bg-clip-text text-transparent md:text-xl'>
+        <span className='text-line'>아직 에피그램이 없어요!</span>
+        <span>에피그램을 만들고 다른 사람들에게 공유할 수 있어요.</span>
+      </p>
+    </motion.div>
+  );
+}

--- a/src/components/ui/header/MainHeader.tsx
+++ b/src/components/ui/header/MainHeader.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 
 export default function MainHeader() {
   return (
-    <header className='border-b-line-100 fixed z-50 flex w-full items-center justify-between border-b-[1px] bg-white px-6 py-[13px] md:px-[72px] md:py-[17px] xl:px-[120px] xl:py-[22px]'>
+    <header className='border-b-line-100 fixed top-0 right-0 left-0 z-10 flex h-16 items-center justify-between border-b-[1px] bg-white px-6 py-[13px] md:px-[72px] md:py-[17px] xl:px-[120px] xl:py-[22px]'>
       <div className='flex items-center justify-center gap-3 md:gap-6 xl:gap-9'>
         <Image src={menuIcon} alt='메뉴 아이콘' className='md:hidden'></Image>
         <Link href={'/'}>
@@ -19,7 +19,7 @@ export default function MainHeader() {
           검색
         </Link>
       </div>
-      <Link href={'/myapage'} className='flex gap-1.5'>
+      <Link href={'/mypage'} className='flex gap-1.5'>
         <Image src={userIconLight} alt='유저 아이콘'></Image>
         <p className='xl:text-md text-sm font-medium text-gray-300'>김코드</p>
       </Link>

--- a/src/components/ui/skeletons/EpigramCardSkeleton.tsx
+++ b/src/components/ui/skeletons/EpigramCardSkeleton.tsx
@@ -1,0 +1,41 @@
+export function MainEpigramSkeleton() {
+  return (
+    <div className='space-y-2'>
+      <div className='rounded-xl border border-gray-100 bg-white p-6 shadow-sm'>
+        <div className='mb-4 space-y-2'>
+          <div className='h-4 w-full animate-pulse rounded bg-gray-200'></div>
+
+          <div className='h-4 w-4/5 animate-pulse rounded bg-gray-200'></div>
+          <div className='h-4 w-11/12 animate-pulse rounded bg-gray-200'></div>
+        </div>
+
+        <div className='mt-4 flex justify-end'>
+          <div className='h-4 w-1/3 animate-pulse rounded bg-gray-200'></div>
+        </div>
+      </div>
+
+      <div className='mt-2 flex justify-end space-x-2'>
+        <div className='h-4 w-24 animate-pulse rounded bg-gray-200'></div>
+        <div className='h-4 w-28 animate-pulse rounded bg-gray-200'></div>
+      </div>
+    </div>
+  );
+}
+
+export function MainEpigramButtonSkeleton() {
+  return (
+    <div className='flex justify-center space-x-2'>
+      <div className='h-10 w-32 animate-pulse rounded-full bg-gray-200'></div>
+    </div>
+  );
+}
+
+export function MainEpigramSkeletonList({ count }: { count: number }) {
+  return (
+    <div className='flex flex-col gap-2'>
+      {Array.from({ length: count }).map((_, i) => (
+        <MainEpigramSkeleton key={i} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## ❓이슈
- close #93 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

메인페이지에 들어가는 에피그램 리스트 컴포넌트 구현에 관한 PR입니다.

더이상 불러올 데이터가 없다면 에피그램 더 보기 버튼이 언마운트 되도록 구현했습니다.

스켈레톤 UI도 적용했습니다.

구현 중 Header 부분에서 z-index 및 postion에서 수정할 부분이 생겨서 불가피하게 수정하였습니다.

epigrams페이지는 레이아웃만 미리 잡아놨습니다.

오늘의 에피그램 컴포넌트에서 디자인이 에피그램 리스트와 일부 달라서 통일시켰고, div에서 link로 변경했습니다.

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
