### PR TITLE
EP-84 오늘의 감정 컴포넌트(마이페이지)

### DIFF
--- a/src/components/epigrams/DailyEmotion.tsx
+++ b/src/components/epigrams/DailyEmotion.tsx
@@ -27,7 +27,7 @@ export default function DailyEmotion() {
             <div className='flex justify-center gap-4'>
               {EMOTION_STATUS.map((emotion, index) => (
                 <motion.div key={index} animate={{ opacity: 1 }} transition={{ duration: 0.2 }} whileHover={{ y: -8, transition: { duration: 0.2 } }} className='flex flex-col items-center gap-2'>
-                  <EmotionButton emotion={emotion} isInteractive onClick={() => handleEmotionClick(emotion)} disabled={isPosting} />
+                  <EmotionButton emotion={emotion} isInteractive onClick={() => handleEmotionClick(emotion)} disabled={isPosting} emotionVariant={isPosting ? 'grayScales' : 'default'} />
                   <span className='text-sub-blue-1 lg:text-2lg text-sm font-semibold md:text-lg'>{EMOTION_STATUS_KR[index]}</span>
                 </motion.div>
               ))}

--- a/src/components/mypage/DailyEmotion.tsx
+++ b/src/components/mypage/DailyEmotion.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { AnimatePresence, motion } from 'motion/react';
+import { EMOTION_STATUS, EMOTION_STATUS_KR } from '@/constants/emotions';
+import EmotionButton from '@/components/ui/emotionButton';
+import { useGetTodayEmotionLog, useOptimisticEmotionLog } from '@/apis/emotion-log/queries';
+import { Emotion } from '@/apis/emotion-log/types';
+import { useEffect, useState } from 'react';
+import dayjs from 'dayjs';
+
+export default function DailyEmotion() {
+  const { mutateAsync: updateEmotionLog } = useOptimisticEmotionLog();
+  const { data: dailyEmotion } = useGetTodayEmotionLog();
+  const [date, setDate] = useState<string | null>(null);
+
+  const handleEmotionClick = async (emotion: Emotion) => {
+    await updateEmotionLog({ emotion });
+  };
+
+  useEffect(() => {
+    const today = new Date();
+    const formattedDate = dayjs(today).format('YYYY.MM.DD');
+    setDate(formattedDate);
+  }, []);
+
+  return (
+    <section className='flex flex-col gap-4 md:gap-8'>
+      <AnimatePresence>
+        {
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0, transition: { duration: 1 } }} className='flex flex-col items-center gap-4'>
+            <div className='flex w-full items-center justify-between'>
+              <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>오늘의 감정</h2>
+              <span className='text-lg text-blue-400 lg:text-xl'>{date}</span>
+            </div>
+            <div className='flex justify-center gap-4'>
+              {EMOTION_STATUS.map((emotion, index) => (
+                <motion.div key={index} animate={{ opacity: 1 }} transition={{ duration: 0.2 }} whileHover={{ y: -8, transition: { duration: 0.2 } }} className='flex flex-col items-center gap-2'>
+                  <EmotionButton emotion={emotion} isInteractive onClick={() => handleEmotionClick(emotion)} buttonVariant={dailyEmotion?.emotion === emotion} />
+                  <span className='text-sub-blue-1 lg:text-2lg text-sm font-semibold md:text-lg'>{EMOTION_STATUS_KR[index]}</span>
+                </motion.div>
+              ))}
+            </div>
+          </motion.div>
+        }
+      </AnimatePresence>
+    </section>
+  );
+}

--- a/src/components/ui/emotionButton/index.tsx
+++ b/src/components/ui/emotionButton/index.tsx
@@ -3,7 +3,7 @@
 import Emotion, { EmotionProps } from '@/components/ui/emotion';
 import { cn } from '@/utils/cn';
 import { cva } from 'class-variance-authority';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Emotion as EmotionType } from '@/apis/emotion-log/types';
 
 const buttonStyles = cva('flex justify-center items-center rounded-2xl cursor-pointer', {
@@ -47,18 +47,18 @@ export default function EmotionButton({ buttonVariant, emotion, emotionVariant, 
   const [currentButtonVariant, setCurrentButtonVariant] = useState(buttonVariant);
 
   const buttonBorderColor = buttonBorderMap[emotion];
-
   const handleClick = () => {
-    setCurrentButtonVariant(!currentButtonVariant);
+    setCurrentButtonVariant(true);
     onClick?.();
   };
+
+  useEffect(() => {
+    setCurrentButtonVariant(buttonVariant);
+  }, [buttonVariant]);
+
   return (
-    <button
-      className={cn(buttonStyles({ isActive: currentButtonVariant, size }), buttonBorderColor, isInteractive && 'size-12 md:size-16 lg:size-20 xl:size-24')}
-      onClick={handleClick}
-      disabled={disabled}
-    >
-      <Emotion variant={emotionVariant} emotion={emotion} size={size} className={cn(isInteractive && 'size-8 sm:size-9 md:size-10 lg:size-11 xl:size-12')} />
+    <button className={cn(buttonStyles({ isActive: currentButtonVariant, size }), buttonBorderColor, isInteractive && 'size-12 md:size-20 xl:size-24')} onClick={handleClick} disabled={disabled}>
+      <Emotion variant={emotionVariant} emotion={emotion} size={size} className={cn(isInteractive && 'size-8 md:size-10 xl:size-12')} />
     </button>
   );
 }


### PR DESCRIPTION
## ❓이슈
- close #117 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

오늘의 감정(마이페이지) 컴포넌트에 관한 PR입니다.

메인페이지와 달리 감정을 선택해도 언마운트 되지 않도록 구현했습니다.

post 상태를 추적할 필요가 없기 때문에 state도 그에 따라 제거했습니다.

기존 EmotionButton 컴포넌트에서 props에 따라 상태가 변화되어야 하는데, 그 로직이 없어서 해당 로직 추가했습니다.(useEffect로 처리)

또한, button의 클릭을 토글로 처리되는 것이 아니기에 활성화 상태를 클릭하면 토글이 아닌 true로 변경했습니다.

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
