### PR TITLE
EP-83 에픽그램 생성 페이지 api 연결 & 해당 id로 페이지로 이동

### DIFF
--- a/src/components/addEditForm/AddEpigramForm.tsx
+++ b/src/components/addEditForm/AddEpigramForm.tsx
@@ -10,8 +10,11 @@ import Author from './Author';
 import Input from '../ui/Field/Input';
 import TagInput from './Tags';
 import Button from '../ui/buttons';
+import { usePostEpigram } from '@/apis/epigram/queries'; 
+import { useRouter } from 'next/navigation'; 
 
 export default function AddEpigramForm() {
+  const router = useRouter();
   const {
     handleSubmit,
     register,
@@ -27,12 +30,31 @@ export default function AddEpigramForm() {
     mode: 'onBlur',
   });
 
+  const { mutate: postEpigram } = usePostEpigram();
+
   const handleTagChange = (newTag: string[]) => {
     setValue('tag', newTag, { shouldValidate: true });
   };
 
   const onSubmit = (data: MakeEpigramForm) => {
-    console.log(data);
+    const epigramForm = {
+      content: data.content,
+      author: data.authorName || '',
+      referenceTitle: data.sourceTitle,
+      referenceUrl: data.sourceUrl,
+      tags: data.tag,
+    };
+
+    postEpigram(epigramForm, {
+      onSuccess: (response) => {
+        if (response && response.id) {
+          router.push(`/epigrams/${response.id}`);
+        }
+      },
+      onError: (error) => {
+        console.error('에피그램 생성 실패:', error);
+      },
+    });
   };
 
   return (

--- a/tests/addEpigramForm.test.tsx
+++ b/tests/addEpigramForm.test.tsx
@@ -2,6 +2,7 @@ import AddEpigramForm from '@/components/addEditForm/AddEpigramForm';
 // import { MakeEpigramApiRequest } from '@/types';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -15,9 +16,26 @@ jest.mock('next/navigation', () => ({
 // }));
 
 describe('AddEpigram Component', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  // QueryClientProvider로 컴포넌트를 감싸는 함수
+  const renderWithQueryClient = () => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <AddEpigramForm />
+      </QueryClientProvider>,
+    );
+  };
+
   beforeEach(() => {
     // mockCreateEpigram.mockClear();
-    render(<AddEpigramForm />);
+    renderWithQueryClient();
   });
 
   test('에피그램 추가폼을 불러온다', () => {


### PR DESCRIPTION
## ❓이슈
- close #116 

## :writing_hand: Description

생성 페이지의 api 연결을 하고
추가적으로 해당 id로 이동하게 작성을 했습니다.
이 pr이 머지되면 수정페이지 작업도 완료를 해서 
제 아이디로 만들고 제가만든 에픽그램을 수정을 테스트 해보려고합니다.

--
성락님의 피드백 대로 실패시의 모달 컴포넌트 가져와서 
trycatch문에서 처리를 해 봤습니다.

 -  throw new Error('테스트용 강제 에러');를 던져서 확인한 결과입니다.
<img width="1095" alt="스크린샷 2025-03-25 오후 1 19 44" src="https://github.com/user-attachments/assets/7623d092-5929-497d-9de1-4e672fc01785" />



<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
