### PR TITLE
EP-94 메인페이지 댓글리스트 리팩토링

### DIFF
--- a/src/components/epigrams/CommentEmptyState.tsx
+++ b/src/components/epigrams/CommentEmptyState.tsx
@@ -1,0 +1,12 @@
+import Image from 'next/image';
+import empty_img from '@/assets/images/empty_epigram.svg';
+
+export default function CommentEmptyState() {
+  return (
+    <div className='flex flex-col items-center justify-center gap-4 py-12'>
+      <Image src={empty_img} alt='댓글 없음' width={150} height={150} />
+      <p className='text-lg text-gray-500'>아직 작성된 댓글이 없습니다.</p>
+      <p className='text-sm text-gray-400'>첫 댓글을 남겨보세요!</p>
+    </div>
+  );
+}

--- a/src/components/epigrams/CommentList.tsx
+++ b/src/components/epigrams/CommentList.tsx
@@ -1,29 +1,24 @@
 'use client';
 
-import { useCommentsQuery, useDeleteComment, useUpdateComment } from '@/apis/comment/queries';
-import Comment from '../ui/comment';
-import RoundedButton from '../ui/buttons/roundedButton';
-import getTimeElapsed from '@/utils/getTimeElapsed';
-import { useModalStore } from '@/stores/ModalStore';
-import EditCommentModal from './EditCommentModal';
+import { useMemo } from 'react';
+import { useCommentsQuery } from '@/apis/comment/queries';
 import { useGetUser } from '@/apis/user/queries';
-import { getErrorMessage } from '@/utils/network/getErrorMessage';
-import { Comment as CommentType, PatchComment } from '@/apis/comment/types';
+import { useCommentActions } from '@/hooks/useCommentActions';
+import getTimeElapsed from '@/utils/getTimeElapsed';
+import Comment from '../ui/comment';
 import CommentsSkeleton from '../ui/skeletons/CommentLIstSkeleton';
-import plus_ic from '@/assets/icons/plus.svg';
+import RoundedButton from '../ui/buttons/roundedButton';
 import Image from 'next/image';
+import plus_ic from '@/assets/icons/plus.svg';
+import CommentEmptyState from './CommentEmptyState';
 
 const PAGE_LIMIT = 4;
 
 export default function CommentList() {
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useCommentsQuery(PAGE_LIMIT);
-  const comments = data?.pages.flatMap((page) => page.list) ?? [];
-  const updateComment = useUpdateComment();
-  const deleteComment = useDeleteComment();
-
+  const comments = useMemo(() => data?.pages.flatMap((page) => page.list) ?? [], [data]);
   const user = useGetUser();
-
-  const { openModal, closeAllModals } = useModalStore();
+  const { handleEditComment, handleDelete } = useCommentActions();
 
   const handleMoreClick = () => {
     if (hasNextPage) {
@@ -31,84 +26,42 @@ export default function CommentList() {
     }
   };
 
-  const handleEditComment = (comment: CommentType) => {
-    openModal({
-      type: 'custom',
-      content: (
-        <EditCommentModal
-          initialContent={comment.content}
-          commentId={comment.id}
-          onSave={async (data: { commentId: number; patchData: PatchComment }) => {
-            try {
-              await updateComment.mutateAsync(data);
-              openModal({
-                type: 'alert',
-                title: '수정 성공',
-                description: '댓글 수정에 성공했습니다.',
-                callback: closeAllModals,
-              });
-            } catch (err) {
-              openModal({
-                type: 'alert',
-                title: '댓글 수정 실패',
-                callback: () => getErrorMessage(err),
-              });
-            }
-          }}
-        />
-      ),
-      size: 'md',
-    });
-  };
+  const renderContent = () => {
+    if (isLoading) {
+      return <CommentsSkeleton count={PAGE_LIMIT} />;
+    }
 
-  const handleDelete = (commentId: number) => {
-    openModal({
-      type: 'confirm',
-      title: '정말 삭제하시겠습니까?',
-      callback: async () => {
-        try {
-          await deleteComment.mutateAsync(commentId);
-          openModal({
-            type: 'alert',
-            title: '삭제 성공',
-            description: '댓글을 삭제했습니다.',
-            callback: closeAllModals,
-          });
-        } catch (err) {
-          openModal({
-            type: 'alert',
-            title: '삭제실패',
-            callback: () => getErrorMessage(err),
-          });
-        }
-      },
-    });
+    if (comments.length === 0) {
+      return <CommentEmptyState />;
+    }
+
+    return (
+      <div className='w-full'>
+        {comments.map((comment) => {
+          const isOwnComment = user.data?.id === comment.writer.id;
+          return (
+            <Comment
+              nickname={comment.writer.nickname}
+              commentTime={getTimeElapsed(comment.updatedAt)}
+              content={comment.content}
+              profileImage={comment.writer.image}
+              isOwnComment={isOwnComment}
+              onEdit={isOwnComment ? () => handleEditComment(comment) : undefined}
+              onDelete={() => handleDelete(comment.id)}
+              key={comment.id}
+            />
+          );
+        })}
+      </div>
+    );
   };
 
   return (
     <section className='flex w-full flex-col gap-4 lg:gap-10'>
       <h3 className='text-black-600 pl-6 text-lg font-semibold md:pl-0 lg:text-2xl'>최신 댓글</h3>
-      {isLoading ? (
-        <CommentsSkeleton count={PAGE_LIMIT} />
-      ) : (
-        <div className='w-full'>
-          {comments.map((comment) => {
-            const isOwnComment = user.data?.id === comment.writer.id;
-            return (
-              <Comment
-                nickname={comment.writer.nickname}
-                commentTime={getTimeElapsed(comment.updatedAt)}
-                content={comment.content}
-                profileImage={comment.writer.image}
-                isOwnComment={isOwnComment}
-                onEdit={isOwnComment ? () => handleEditComment(comment) : undefined}
-                onDelete={() => handleDelete(comment.id)}
-                key={comment.id}
-              />
-            );
-          })}
-        </div>
-      )}
+
+      {renderContent()}
+
       {isFetchingNextPage && <CommentsSkeleton count={PAGE_LIMIT} />}
       <div className='flex justify-center'>
         {hasNextPage && (

--- a/src/components/epigrams/EditCommentModal.tsx
+++ b/src/components/epigrams/EditCommentModal.tsx
@@ -6,16 +6,19 @@ import Button from '../ui/buttons';
 
 interface EditCommentModalProps {
   initialContent?: string;
+  initialPrivate?: boolean;
   commentId: number;
   onSave: (data: { commentId: number; patchData: PatchComment }) => Promise<void>;
 }
 
-export default function EditCommentModal({ initialContent = '', commentId, onSave }: EditCommentModalProps) {
+const MAX_LENGTH = 500;
+
+export default function EditCommentModal({ initialContent = '', initialPrivate = false, commentId, onSave }: EditCommentModalProps) {
   const [content, setContent] = useState(initialContent);
-  const [isPrivate, setIsPrivate] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(initialPrivate);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const isSaveDisabled = (initialContent === content && !isPrivate) || isSubmitting;
+  const isSaveDisabled = (initialContent === content && initialPrivate === isPrivate) || isSubmitting || content.trim().length === 0;
 
   const handleSave = async () => {
     setIsSubmitting(true);
@@ -30,7 +33,7 @@ export default function EditCommentModal({ initialContent = '', commentId, onSav
     <div className='flex w-full flex-col gap-6'>
       <h3 className='text-2lg text-black-500 font-semibold'>댓글 수정</h3>
       <div className='w-full'>
-        <TextArea className='w-full resize-none' value={content} onChange={(e) => setContent(e.target.value)} maxLength={500} />
+        <TextArea className='w-full resize-none' value={content} onChange={(e) => setContent(e.target.value)} maxLength={MAX_LENGTH} />
       </div>
       <div className='flex w-full justify-between'>
         <ToggleButton isSelected={isPrivate} label='비공개' onToggle={(newState) => setIsPrivate(newState)} />

--- a/src/components/epigrams/EditCommentModal.tsx
+++ b/src/components/epigrams/EditCommentModal.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
+import { PatchComment } from '@/apis/comment/types';
 import TextArea from '../ui/textarea';
 import ToggleButton from '../ui/toggleBtn';
 import Button from '../ui/buttons';
-import { PatchComment } from '@/apis/comment/types';
 
 interface EditCommentModalProps {
   initialContent?: string;
@@ -13,10 +13,16 @@ interface EditCommentModalProps {
 export default function EditCommentModal({ initialContent = '', commentId, onSave }: EditCommentModalProps) {
   const [content, setContent] = useState(initialContent);
   const [isPrivate, setIsPrivate] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isSaveDisabled = (initialContent === content && !isPrivate) || isSubmitting;
 
   const handleSave = async () => {
-    if (onSave) {
+    setIsSubmitting(true);
+    try {
       await onSave({ commentId, patchData: { content, isPrivate } });
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -24,12 +30,12 @@ export default function EditCommentModal({ initialContent = '', commentId, onSav
     <div className='flex w-full flex-col gap-6'>
       <h3 className='text-2lg text-black-500 font-semibold'>댓글 수정</h3>
       <div className='w-full'>
-        <TextArea className='w-full resize-none' value={content} onChange={(e) => setContent(e.target.value)} />
+        <TextArea className='w-full resize-none' value={content} onChange={(e) => setContent(e.target.value)} maxLength={500} />
       </div>
       <div className='flex w-full justify-between'>
         <ToggleButton isSelected={isPrivate} label='비공개' onToggle={(newState) => setIsPrivate(newState)} />
-        <Button size='xs' onClick={handleSave}>
-          저장
+        <Button size='xs' onClick={handleSave} disabled={isSaveDisabled}>
+          {isSubmitting ? '저장 중...' : '저장'}
         </Button>
       </div>
     </div>

--- a/src/components/ui/comment/index.tsx
+++ b/src/components/ui/comment/index.tsx
@@ -41,7 +41,7 @@ export default function Comment({ isOwnComment, nickname, commentTime, content, 
         </div>
 
         {/* 댓글 내용 */}
-        <div className='text-black-700 text-md sm:text-md md:text-lg lg:text-xl'>{content}</div>
+        <div className='text-black-700 text-md sm:text-md break-all md:text-lg lg:text-xl'>{content}</div>
       </div>
     </div>
   );

--- a/src/hooks/useCommentActions.tsx
+++ b/src/hooks/useCommentActions.tsx
@@ -1,0 +1,76 @@
+import { useDeleteComment, useUpdateComment } from '@/apis/comment/queries';
+import { useModalStore } from '@/stores/ModalStore';
+import { useCallback } from 'react';
+import { Comment as CommentType, PatchComment } from '@/apis/comment/types';
+import EditCommentModal from '@/components/epigrams/EditCommentModal';
+import { getErrorMessage } from '@/utils/network/getErrorMessage';
+
+export function useCommentActions() {
+  const { openModal, closeAllModals } = useModalStore();
+  const updateComment = useUpdateComment();
+  const deleteComment = useDeleteComment();
+
+  const handleEditComment = useCallback(
+    (comment: CommentType) => {
+      openModal({
+        type: 'custom',
+        content: (
+          <EditCommentModal
+            initialContent={comment.content}
+            commentId={comment.id}
+            onSave={async (data: { commentId: number; patchData: PatchComment }) => {
+              try {
+                await updateComment.mutateAsync(data);
+                openModal({
+                  type: 'alert',
+                  title: '수정 성공',
+                  description: '댓글 수정에 성공했습니다.',
+                  callback: closeAllModals,
+                });
+              } catch (err) {
+                openModal({
+                  type: 'alert',
+                  title: '댓글 수정 실패',
+                  description: getErrorMessage(err),
+                  callback: closeAllModals,
+                });
+              }
+            }}
+          />
+        ),
+        size: 'md',
+      });
+    },
+    [openModal, updateComment, closeAllModals],
+  );
+
+  const handleDelete = useCallback(
+    (commentId: number) => {
+      openModal({
+        type: 'confirm',
+        title: '정말 삭제하시겠습니까?',
+        callback: async () => {
+          try {
+            await deleteComment.mutateAsync(commentId);
+            openModal({
+              type: 'alert',
+              title: '삭제 성공',
+              description: '댓글을 삭제했습니다.',
+              callback: closeAllModals,
+            });
+          } catch (err) {
+            openModal({
+              type: 'alert',
+              title: '삭제실패',
+              description: getErrorMessage(err),
+              callback: closeAllModals,
+            });
+          }
+        },
+      });
+    },
+    [openModal, deleteComment, closeAllModals],
+  );
+
+  return { handleEditComment, handleDelete };
+}


### PR DESCRIPTION
## ❓이슈
- close #138 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
- 내 댓글 수정, 삭제 관련 모달을 부르는 부분을 커스텀 훅으로 분리했습니다.
- 마이페이지, 상세 페이지에서 내 댓글 수정,삭제에서도 사용하시면 좋을거 같습니다.
- 댓글 수정 시 변경값이 없을 경우 요청을 보내지 않게 수정 
- 아무것도 입력하지 않고 버튼을 누르려하면 저장 버튼을 못누르게 수정
- content에 변경사항이 없고 공개 비공개 상태도 변경하지 않았을 경우 저장하지 못하게 수정
- 댓글 리스트가 없을 경우 empty 이미지 처리 
- return 문 안에서 empty, skeleton, isFetchingNextPage, 전부 처리하려고 하니 return 문 안 코드가 너무 더러워지는것 같아서 조기 반환 패턴으로 리팩토링하였습니다.
- E2E, Jest 테스트 모두 전부 통과했는데 우선 workflow 과정에서 오류 발생하면 다시 이슈 만들어서 수정하겠습니다
- 댓글이 길어질 경우 댓글 컴포넌트 밖으로 content가 overflow되어서 Comment 컴포넌트에 break-all 속성 추가해두었습니다.

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
