### PR TITLE
EP-97 에픽그램 수정, 생성 페이지 리팩토링 

### DIFF
--- a/src/apis/epigram/index.ts
+++ b/src/apis/epigram/index.ts
@@ -42,8 +42,12 @@ export const getEpigram = async (epigramId: number) => {
  * https://fe-project-epigram-api.vercel.app/docs/#/Epigram/UpdateEpigram
  */
 export const patchEpigram = async (epigramId: number, epigram: PatchEpigram) => {
-  const response = await axiosClientHelper.patch<Epigram>(`/epigrams/${epigramId}`, { ...epigram });
-  return safeResponse(response.data, epigramSchema);
+  try{const response = await axiosClientHelper.patch<Epigram>(`/epigrams/${epigramId}`, { ...epigram });
+  return safeResponse(response.data, epigramSchema);}
+  catch (error) {
+    console.error('🚨 patchEpigram Error:', error.response?.data || error.message);
+    throw error;
+  }
 };
 
 /**

--- a/src/apis/epigram/index.ts
+++ b/src/apis/epigram/index.ts
@@ -42,12 +42,8 @@ export const getEpigram = async (epigramId: number) => {
  * https://fe-project-epigram-api.vercel.app/docs/#/Epigram/UpdateEpigram
  */
 export const patchEpigram = async (epigramId: number, epigram: PatchEpigram) => {
-  try{const response = await axiosClientHelper.patch<Epigram>(`/epigrams/${epigramId}`, { ...epigram });
-  return safeResponse(response.data, epigramSchema);}
-  catch (error) {
-    console.error('🚨 patchEpigram Error:', error.response?.data || error.message);
-    throw error;
-  }
+  const response = await axiosClientHelper.patch<Epigram>(`/epigrams/${epigramId}`, { ...epigram });
+  return safeResponse(response.data, epigramSchema);
 };
 
 /**

--- a/src/components/addEditForm/AddEpigramForm.tsx
+++ b/src/components/addEditForm/AddEpigramForm.tsx
@@ -14,11 +14,9 @@ import { usePostEpigram } from '@/apis/epigram/queries';
 import { useRouter } from 'next/navigation';
 import { useModalStore } from '@/stores/ModalStore';
 
-
 export default function AddEpigramForm() {
   const router = useRouter();
   const { openModal } = useModalStore();
-
 
   const {
     handleSubmit,

--- a/src/components/addEditForm/AddEpigramForm.tsx
+++ b/src/components/addEditForm/AddEpigramForm.tsx
@@ -43,8 +43,8 @@ export default function AddEpigramForm() {
     const epigramForm = {
       content: data.content,
       author: data.author || '',
-      referenceTitle: data.referenceTitle,
-      referenceUrl: data.referenceUrl,
+      ...(data.referenceTitle && { referenceTitle: data.referenceTitle }),
+      ...(data.referenceUrl && { referenceUrl: data.referenceUrl }),
       tags: data.tags,
     };
 

--- a/src/components/addEditForm/AddEpigramForm.tsx
+++ b/src/components/addEditForm/AddEpigramForm.tsx
@@ -64,22 +64,22 @@ export default function AddEpigramForm() {
 
   return (
     <>
-      <EpigramFormLayout onSubmit={handleSubmit(onSubmit)}>
+      <EpigramFormLayout className='flex flex-col gap-6 md:gap-8 lg:gap-10' onSubmit={handleSubmit(onSubmit)}>
         <h1 className='text-lg font-bold md:text-xl lg:text-2xl'>에피그램 만들기</h1>
-        <div>
-          <Content register={register} errors={errors} trigger={trigger} />
-        </div>
-        <div className='pt-10 lg:pt-14'>
-          <Author register={register} watch={watch} setValue={setValue} errors={errors} trigger={trigger} />
-        </div>
-        <div className='flex flex-col gap-4 pt-10 lg:pt-14'>
-          <Input label='출처' {...register('sourceTitle')} error={errors.sourceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
-          <Input {...register('sourceUrl')} error={errors.sourceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
-        </div>
-        <div className='pt-10 lg:pt-14'>
-          <TagInput value={watch('tag')} onChange={handleTagChange} error={errors.tag?.message} />
-        </div>
-        <div className='pt-10 md:pt-6 lg:pt-6'>
+        <div className='flex flex-col gap-6 md:gap-8 lg:gap-10'>
+          <div className='flex flex-col gap-10 md:gap-9.75 lg:gap-10'>
+            <Content register={register} errors={errors} trigger={trigger} />
+
+            <Author register={register} watch={watch} setValue={setValue} errors={errors} trigger={trigger} />
+
+            <div className='flex flex-col gap-4'>
+              <Input label='출처' {...register('sourceTitle')} error={errors.sourceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
+              <Input {...register('sourceUrl')} error={errors.sourceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
+            </div>
+
+            <TagInput value={watch('tag')} onChange={handleTagChange} error={errors.tag?.message} />
+          </div>
+
           <Button type='submit' variant='default' className='w-full' disabled={!watch('content') || watch('content').length > 500 || (watch('authorType') === 'direct' && !watch('authorName'))}>
             작성 완료
           </Button>

--- a/src/components/addEditForm/AddEpigramForm.tsx
+++ b/src/components/addEditForm/AddEpigramForm.tsx
@@ -19,6 +19,7 @@ export default function AddEpigramForm() {
   const router = useRouter();
   const { openModal } = useModalStore();
 
+
   const {
     handleSubmit,
     register,
@@ -37,16 +38,16 @@ export default function AddEpigramForm() {
   const { mutateAsync: postEpigram } = usePostEpigram();
 
   const handleTagChange = (newTag: string[]) => {
-    setValue('tag', newTag, { shouldValidate: true });
+    setValue('tags', newTag, { shouldValidate: true });
   };
 
   const onSubmit = async (data: MakeEpigramForm) => {
     const epigramForm = {
       content: data.content,
-      author: data.authorName || '',
-      referenceTitle: data.sourceTitle,
-      referenceUrl: data.sourceUrl,
-      tags: data.tag,
+      author: data.author || '',
+      referenceTitle: data.referenceTitle,
+      referenceUrl: data.referenceUrl,
+      tags: data.tags,
     };
 
     try {
@@ -74,14 +75,14 @@ export default function AddEpigramForm() {
             <Author register={register} watch={watch} setValue={setValue} errors={errors} trigger={trigger} />
 
             <div className='flex flex-col gap-4'>
-              <Input label='출처' {...register('sourceTitle')} error={errors.sourceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
-              <Input {...register('sourceUrl')} error={errors.sourceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
+              <Input label='출처' {...register('referenceTitle')} error={errors.referenceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
+              <Input {...register('referenceUrl')} error={errors.referenceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
             </div>
 
-            <TagInput value={watch('tag')} onChange={handleTagChange} error={errors.tag?.message} />
+            <TagInput value={watch('tags')} onChange={handleTagChange} error={errors.tags?.message} />
           </div>
 
-          <Button type='submit' variant='default' className='w-full' disabled={!watch('content') || watch('content').length > 500 || (watch('authorType') === 'direct' && !watch('authorName'))}>
+          <Button type='submit' variant='default' className='w-full' disabled={!watch('content') || watch('content').length > 500 || (watch('authorType') === 'direct' && !watch('author'))}>
             작성 완료
           </Button>
         </div>

--- a/src/components/addEditForm/AddEpigramForm.tsx
+++ b/src/components/addEditForm/AddEpigramForm.tsx
@@ -14,6 +14,7 @@ import { usePostEpigram } from '@/apis/epigram/queries';
 import { useRouter } from 'next/navigation';
 import { useModalStore } from '@/stores/ModalStore';
 
+
 export default function AddEpigramForm() {
   const router = useRouter();
   const { openModal } = useModalStore();

--- a/src/components/addEditForm/Author.tsx
+++ b/src/components/addEditForm/Author.tsx
@@ -4,12 +4,12 @@ import Input from '@/components/ui/Field/Input';
 import { RadioGroup } from '../ui/radio/RadioGroup';
 import { RadioItem } from '../ui/radio/RadioItem';
 import { AuthorProps } from '@/components/addEditForm/types';
-import { useGetUser } from '@/apis/user/queries'; 
+import { useGetUser } from '@/apis/user/queries';
 
 export default function Author({ register, watch, setValue, errors, trigger }: AuthorProps) {
   const authorType = watch('authorType');
   const { data: user } = useGetUser();
-  const userNickname = user?.nickname || ''; 
+  const userNickname = user?.nickname || '';
 
   const getRadioValue = (authorType: string) => {
     if (authorType === 'myself') return 'myself';
@@ -39,9 +39,15 @@ export default function Author({ register, watch, setValue, errors, trigger }: A
 
       <div className='flex h-20.5 w-full flex-col gap-3 xl:h-28 xl:gap-4'>
         <RadioGroup className='flex h-6.5 w-full xl:h-8' value={getRadioValue(authorType)} onValueChange={handleRadioChange} defaultValue='custom'>
-          <RadioItem radioSize='sm' value='custom' id='custom' label='직접 입력' />
-          <RadioItem radioSize='sm' value='unknown' id='unknown' label='알 수 없음' />
-          <RadioItem radioSize='sm' value='myself' id='myself' label='본인' />
+          <div className='cursor-pointer'>
+            <RadioItem radioSize='sm' value='custom' id='custom' label='직접 입력' />
+          </div>
+          <div className='cursor-pointer'>
+            <RadioItem radioSize='sm' value='unknown' id='unknown' label='알 수 없음' />
+          </div>
+          <div className='cursor-pointer'>
+            <RadioItem radioSize='sm' value='myself' id='myself' label='본인' />
+          </div>
         </RadioGroup>
         <Input
           className='h-11 w-full xl:h-16'

--- a/src/components/addEditForm/Author.tsx
+++ b/src/components/addEditForm/Author.tsx
@@ -4,9 +4,12 @@ import Input from '@/components/ui/Field/Input';
 import { RadioGroup } from '../ui/radio/RadioGroup';
 import { RadioItem } from '../ui/radio/RadioItem';
 import { AuthorProps } from '@/components/addEditForm/types';
+import { useGetUser } from '@/apis/user/queries'; 
 
 export default function Author({ register, watch, setValue, errors, trigger }: AuthorProps) {
   const authorType = watch('authorType');
+  const { data: user } = useGetUser();
+  const userNickname = user?.nickname || ''; 
 
   const getRadioValue = (authorType: string) => {
     if (authorType === 'myself') return 'myself';
@@ -17,10 +20,13 @@ export default function Author({ register, watch, setValue, errors, trigger }: A
   const handleRadioChange = (value: string) => {
     if (value === 'myself') {
       setValue('authorType', 'myself');
+      setValue('authorName', userNickname);
     } else if (value === 'unknown') {
       setValue('authorType', 'unknown');
+      setValue('authorName', '알 수 없음');
     } else {
       setValue('authorType', 'direct');
+      setValue('authorName', '');
     }
   };
 

--- a/src/components/addEditForm/Author.tsx
+++ b/src/components/addEditForm/Author.tsx
@@ -20,13 +20,13 @@ export default function Author({ register, watch, setValue, errors, trigger }: A
   const handleRadioChange = (value: string) => {
     if (value === 'myself') {
       setValue('authorType', 'myself');
-      setValue('authorName', userNickname);
+      setValue('author', userNickname);
     } else if (value === 'unknown') {
       setValue('authorType', 'unknown');
-      setValue('authorName', '알 수 없음');
+      setValue('author', '알 수 없음');
     } else {
       setValue('authorType', 'direct');
-      setValue('authorName', '');
+      setValue('author', '');
     }
   };
 
@@ -53,9 +53,9 @@ export default function Author({ register, watch, setValue, errors, trigger }: A
           className='h-11 w-full xl:h-16'
           maxLength={20}
           disabled={authorType !== 'direct'}
-          {...register('authorName', { required: authorType === 'direct' ? '저자 이름을 입력해주세요' : false, onBlur: () => authorType === 'direct' && trigger('authorName') })}
+          {...register('author', { required: authorType === 'direct' ? '저자 이름을 입력해주세요' : false, onBlur: () => authorType === 'direct' && trigger('author') })}
           placeholder={authorType === 'direct' ? '저자 이름 입력' : authorType === 'unknown' ? '알 수 없음' : '본인'}
-          error={errors.authorName?.message}
+          error={errors.author?.message}
           variant='outlined'
         />
       </div>

--- a/src/components/addEditForm/EditEpigramForm.tsx
+++ b/src/components/addEditForm/EditEpigramForm.tsx
@@ -22,6 +22,7 @@ export default function EditEpigramForm({ id }: { id: number }) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { openModal } = useModalStore();
+  
 
   const {
     handleSubmit,
@@ -41,21 +42,29 @@ export default function EditEpigramForm({ id }: { id: number }) {
   useEffect(() => {
     if (data) {
       setValue('content', data.content || '');
-      setValue('authorName', data.author || '');
-      setValue('sourceTitle', data.referenceTitle || '');
-      setValue('sourceUrl', data.referenceUrl || '');
-      setValue('tag', data.tags?.map((tag) => tag.name) || []);
+      setValue('author', data.author || '');
+      setValue('referenceTitle', data.referenceTitle || '');
+      setValue('referenceUrl', data.referenceUrl || '');
+      setValue('tags', data.tags?.map((tag) => tag.name) || []);
     }
   }, [data, setValue]);
 
   const handleTagChange = (newTag: string[]) => {
-    setValue('tag', newTag, { shouldValidate: true });
+    setValue('tags', newTag, { shouldValidate: true });
   };
 
   const onSubmit = async (data: MakeEpigramForm) => {
+    const epigramForm = {
+      content: data.content,
+      author: data.author || '',
+      referenceTitle: data.referenceTitle,
+      referenceUrl: data.referenceUrl,
+      tags: data.tags,
+    };
+
     setIsSubmitting(true);
     patchEpigram(
-      { epigramId: id, epigram: data },
+      { epigramId: id, epigram:  epigramForm },
       {
         onSuccess: () => {
           openModal({
@@ -89,18 +98,18 @@ export default function EditEpigramForm({ id }: { id: number }) {
             <Author register={register} watch={watch} setValue={setValue} errors={errors} trigger={trigger} />
 
             <div className='flex flex-col gap-4'>
-              <Input label='출처' {...register('sourceTitle')} error={errors.sourceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
-              <Input {...register('sourceUrl')} error={errors.sourceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
+              <Input label='출처' {...register('referenceTitle')} error={errors.referenceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
+              <Input {...register('referenceUrl')} error={errors.referenceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
             </div>
 
-            <TagInput value={watch('tag')} onChange={handleTagChange} error={errors.tag?.message} />
+            <TagInput value={watch('tags')} onChange={handleTagChange} error={errors.tags?.message} />
           </div>
 
           <Button
             type='submit'
             variant='default'
             className='w-full'
-            disabled={!watch('content') || watch('content').length > 500 || (watch('authorType') === 'direct' && !watch('authorName')) || isSubmitting}
+            disabled={!watch('content') || watch('content').length > 500 || (watch('authorType') === 'direct' && !watch('author')) || isSubmitting}
           >
             {isSubmitting ? '수정 중...' : '수정 완료'}
           </Button>

--- a/src/components/addEditForm/EditEpigramForm.tsx
+++ b/src/components/addEditForm/EditEpigramForm.tsx
@@ -57,8 +57,8 @@ export default function EditEpigramForm({ id }: { id: number }) {
     const epigramForm = {
       content: data.content,
       author: data.author || '',
-      referenceTitle: data.referenceTitle,
-      referenceUrl: data.referenceUrl,
+      ...(data.referenceTitle && { referenceTitle: data.referenceTitle }),
+      ...(data.referenceUrl && { referenceUrl: data.referenceUrl }),
       tags: data.tags,
     };
 

--- a/src/components/addEditForm/EditEpigramForm.tsx
+++ b/src/components/addEditForm/EditEpigramForm.tsx
@@ -80,22 +80,22 @@ export default function EditEpigramForm({ id }: { id: number }) {
 
   return (
     <>
-      <EpigramFormLayout onSubmit={handleSubmit(onSubmit)}>
+      <EpigramFormLayout className='flex flex-col gap-6 md:gap-8 lg:gap-10' onSubmit={handleSubmit(onSubmit)}>
         <h1 className='text-lg font-bold md:text-xl lg:text-2xl'>에피그램 수정</h1>
-        <div>
-          <Content register={register} errors={errors} trigger={trigger} />
-        </div>
-        <div className='pt-10 lg:pt-14'>
-          <Author register={register} watch={watch} setValue={setValue} errors={errors} trigger={trigger} />
-        </div>
-        <div className='flex flex-col gap-4 pt-10 lg:pt-14'>
-          <Input label='출처' {...register('sourceTitle')} error={errors.sourceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
-          <Input {...register('sourceUrl')} error={errors.sourceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
-        </div>
-        <div className='pt-10 lg:pt-14'>
-          <TagInput value={watch('tag')} onChange={handleTagChange} error={errors.tag?.message} />
-        </div>
-        <div className='pt-10 md:pt-6 lg:pt-6'>
+        <div className='flex flex-col gap-6 md:gap-8 lg:gap-10'>
+          <div className='flex flex-col gap-10 md:gap-9.75 lg:gap-10'>
+            <Content register={register} errors={errors} trigger={trigger} />
+
+            <Author register={register} watch={watch} setValue={setValue} errors={errors} trigger={trigger} />
+
+            <div className='flex flex-col gap-4'>
+              <Input label='출처' {...register('sourceTitle')} error={errors.sourceTitle?.message} placeholder='출처 제목 입력' variant='outlined' />
+              <Input {...register('sourceUrl')} error={errors.sourceUrl?.message} placeholder='URL (ex. https://www.website.com)' variant='outlined' />
+            </div>
+
+            <TagInput value={watch('tag')} onChange={handleTagChange} error={errors.tag?.message} />
+          </div>
+
           <Button
             type='submit'
             variant='default'

--- a/src/components/addEditForm/schemas.ts
+++ b/src/components/addEditForm/schemas.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const MakeEpigramFormSchema = z.object({
   content: z.string().min(1, '내용을 입력해주세요.').max(500, '500자를 초과할 수 없습니다'),
   authorType: z.enum(['direct', 'unknown', 'myself']),
-  authorName: z.string().optional().pipe(z.string().min(1, '저자 이름을 입력해주세요').optional()),
-  sourceTitle: z.string().optional(),
-  sourceUrl: z.union([z.literal(''), z.string().url('올바른 URL 형식이 아닙니다')]).optional(),
-  tag: z.array(z.string()).default([]),
+  author: z.string().optional().pipe(z.string().min(1, '저자 이름을 입력해주세요').optional()),
+  referenceTitle: z.string().optional(),
+  referenceUrl: z.union([z.literal(''), z.string().url('올바른 URL 형식이 아닙니다')]).optional(),
+  tags: z.array(z.string()).default([]),
 });

--- a/src/components/addEditForm/schemas.ts
+++ b/src/components/addEditForm/schemas.ts
@@ -5,6 +5,12 @@ export const MakeEpigramFormSchema = z.object({
   authorType: z.enum(['direct', 'unknown', 'myself']),
   author: z.string().optional().pipe(z.string().min(1, '저자 이름을 입력해주세요').optional()),
   referenceTitle: z.string().optional(),
-  referenceUrl: z.union([z.literal(''), z.string().url('올바른 URL 형식이 아닙니다')]).optional(),
+  referenceUrl: z
+    .union([z.literal(''), z.string()])
+    .optional()
+    .refine((url) => !url || /^https:\/\/.+/i.test(url), {
+      message: 'URL은 https:// 로 시작해야 합니다.',
+    }),
+
   tags: z.array(z.string()).default([]),
 });


### PR DESCRIPTION
## ❓이슈
- close #146 

## :writing_hand: Description

- 수정, 만들기 페이지의 gap이 피그마 시안과 달리 붙어있어서 갭을 수정하고 그러기 위해 구조를 살짝 변경했습니다.

- 만들기 페이지 알수없음, 본인으로 설정시 만들기 안되는 이슈가 발생하여, setValue로 값을 지정해 전달이 되게 했습니다.


- radio 부분에 커서 포인트 추가는 RadioGroup에 className으로 'cursor-pointer'로 한 번에 주려다가
  개별적으로 주고싶어 RadioItem에 클래스네임을 허용을 안해서 div로 감싸서 줬습니다.

- 본인일 때 닉네임 기입되게 수정했습니다. useGetUse을 이용하여 가져왔습니다. 

- 스키마의 프로퍼티 및 타입을 api 명세서의 프로퍼티 이름과 통일시켰습니다. 

--------

## 추가적으로 도균님의 피드백 내용 
1. 폼 제출시 타이틀 제목,내용은 필수가 아님, 즉, 빈 문자열 일때 요청에서 제외시키는 게 좋아보임 안 그러면 400에러 발생
2. Url 입력할때, 유효성 검사 https 거치고 명시적으로 표현 

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
