### PR TITLE
EP-108 피드 페이지 구현 및 E2E

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -58,6 +58,7 @@ jobs:
           echo "GOOGLE_SECRET_KEY=${{ secrets.GOOGLE_SECRET_KEY }}" >> .env
           echo "NEXT_PUBLIC_PRODUCTION_DOMAIN=${{ secrets.NEXT_PUBLIC_PRODUCTION_DOMAIN }}" >> .env
           echo "NEXT_PUBLIC_LOCAL_DOMAIN=${{ secrets.NEXT_PUBLIC_LOCAL_DOMAIN }}" >> .env
+          echo "DOMAIN=${{ secrets.DOMAIN }}" >> .env
       
       # 9. Next.js 빌드
       - name: Build Next.js app

--- a/e2e/feed.spec.ts
+++ b/e2e/feed.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, BrowserContext, Page } from '@playwright/test';
+
+test.describe('로그인 이전 피드 페이지', () => {
+  test('로그아웃 된 상태에서 접속 시 로그인 페이지로 리다이렉트 된다.', async ({ page }) => {
+    await page.goto('/feed');
+    await expect(page).toHaveURL('http://localhost:3000/login');
+  });
+});
+
+test.describe('로그인 이후 피드 페이지', () => {
+  let context: BrowserContext;
+  let page: Page;
+
+  test.beforeEach(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    await page.goto('/login');
+    await page.waitForTimeout(1000);
+    await page.getByTestId('email-input-login').fill('test5@email.com');
+    await page.getByTestId('password-input-login').fill('password1!');
+    await page.getByRole('button', { name: '로그인' }).click();
+    await page.getByRole('button', { name: '확인' }).click();
+    await page.goto('/feed');
+    await page.waitForTimeout(1000);
+  });
+
+  test.afterEach(async () => {
+    await context.close();
+  });
+
+  test('피드 페이지 로드 확인', async () => {
+    await expect(page).toHaveURL('http://localhost:3000/feed');
+  });
+
+  test('헤더의 로고를 클릭하면 랜딩페이지로 이동한다.', async () => {
+    await page.getByRole('link', { name: '헤더 로고' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/');
+  });
+
+  test('헤더의 피드 링크를 클릭하면 피드 페이지로 이동한다.', async () => {
+    await page.getByRole('link', { name: '피드' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/feed');
+  });
+
+  test('헤더의 검색 링크를 클릭하면 검색 페이지로 이동한다.', async () => {
+    await page.getByRole('link', { name: '검색' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/search');
+  });
+
+  test('헤더의 프로필 이미지를 클릭하면 마이페이지로 이동한다', async () => {
+    await page.getByRole('link', { name: '프로필 이미지' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/mypage');
+  });
+
+  test('피드 페이지에서 에피그램 카드 클릭 시 상세 페이지로 이동한다.', async () => {
+    await page.locator('section').filter({ hasText: '피드' }).getByRole('link').nth(0).click();
+    await expect(page).toHaveURL(/\/epigrams\/\d+$/);
+  });
+
+  test('에피그램 더 보기 버튼 클릭 시 에피그램을 더 불러온다.', async () => {
+    const epigramItemsLocator = page.locator('section').filter({ hasText: '피드' }).getByRole('link');
+    const initialCount = await epigramItemsLocator.count();
+
+    await page.getByRole('button', { name: '에피그램 더보기' }).click();
+    await page.waitForTimeout(1000);
+
+    const newCount = await epigramItemsLocator.count();
+    expect(newCount).toBeGreaterThan(initialCount);
+  });
+
+  test('플로팅 액션 버튼을 클릭하면 스크롤 최상단으로 이동한다.', async () => {
+    await page.getByRole('button', { name: '에피그램 더보기' }).click();
+    await page.waitForTimeout(1000);
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    const scrollPositionBefore = await page.evaluate(() => window.scrollY);
+    expect(scrollPositionBefore).toBeGreaterThan(0);
+
+    await page.getByRole('button', { name: '플로팅 액션 버튼 이미지' }).click();
+
+    await page.waitForTimeout(1000);
+
+    const scrollPositionAfter = await page.evaluate(() => window.scrollY);
+    expect(scrollPositionAfter).toBe(0);
+  });
+
+  test('에피그램 만들기 버튼을 클릭하면 에피그램 생성 페이지로 이동한다', async () => {
+    await page.getByRole('button', { name: '에피그램 만들기' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/addepigram');
+  });
+
+  test('정렬 아이콘을 클릭하면 grid <--> flex 레이아웃이 토글된다.', async () => {
+    await page.getByRole('img', { name: 'y축 정렬 아이콘' }).click();
+    const flexLayoutClass = await page.getByTestId('feed-layout').getAttribute('class');
+    expect(flexLayoutClass?.includes('flex')).toBeTruthy();
+
+    await page.getByRole('img', { name: '표 정렬 아이콘' }).click();
+    const gridLayoutClass = await page.getByTestId('feed-layout').getAttribute('class');
+    expect(gridLayoutClass?.includes('grid')).toBeTruthy();
+  });
+});

--- a/src/app/(after-login)/(background-gray)/feed/page.tsx
+++ b/src/app/(after-login)/(background-gray)/feed/page.tsx
@@ -1,3 +1,11 @@
+import EpigramList from '@/components/feed/EpigramList';
+
 export default function Feed() {
-  return <div>피드 페이지</div>;
+  return (
+    <div className='flex w-full flex-col items-center gap-18 lg:gap-40'>
+      <div className='flex w-full max-w-[1200px] flex-col gap-18 px-6 lg:gap-40'>
+        <EpigramList />
+      </div>
+    </div>
+  );
 }

--- a/src/app/(auth)/oauth/signup/[...provider]/route.ts
+++ b/src/app/(auth)/oauth/signup/[...provider]/route.ts
@@ -22,14 +22,14 @@ export const GET = async (req: NextRequest) => {
     response.cookies.set('accessToken', apiResponse.data.accessToken, {
       httpOnly: true,
       sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
+      secure: process.env.DOMAIN === process.env.NEXT_PUBLIC_PRODUCTION_DOMAIN,
       path: '/',
       expires: accessTokenExp || undefined,
     });
     response.cookies.set('refreshToken', apiResponse.data.refreshToken, {
       httpOnly: true,
       sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
+      secure: process.env.DOMAIN === process.env.NEXT_PUBLIC_PRODUCTION_DOMAIN,
       path: '/',
       expires: refreshTokenExp || undefined,
     });

--- a/src/app/api/[...endpoint]/route.ts
+++ b/src/app/api/[...endpoint]/route.ts
@@ -49,14 +49,14 @@ export const POST = async (request: NextRequest) => {
       response.cookies.set('accessToken', apiResponse.data.accessToken, {
         httpOnly: true,
         sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
+        secure: process.env.DOMAIN === process.env.NEXT_PUBLIC_PRODUCTION_DOMAIN,
         path: '/',
         expires: accessTokenExp || undefined,
       });
       response.cookies.set('refreshToken', apiResponse.data.refreshToken, {
         httpOnly: true,
         sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
+        secure: process.env.DOMAIN === process.env.NEXT_PUBLIC_PRODUCTION_DOMAIN,
         path: '/',
         expires: refreshTokenExp || undefined,
       });

--- a/src/app/api/auth/refresh-token/route.ts
+++ b/src/app/api/auth/refresh-token/route.ts
@@ -25,7 +25,7 @@ export const POST = async () => {
     response.cookies.set('accessToken', accessToken, {
       httpOnly: true,
       sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
+      secure: process.env.DOMAIN === process.env.NEXT_PUBLIC_PRODUCTION_DOMAIN,
       path: '/',
       expires: accessTokenExp || undefined,
     });

--- a/src/components/feed/EpigramList.tsx
+++ b/src/components/feed/EpigramList.tsx
@@ -58,7 +58,7 @@ export default function EpigramList() {
         />
       </div>
       <>
-        <div className={!isLoading && isEmpty(epigrams) ? LIST_LAYOUT.flex : layout}>
+        <div className={!isLoading && isEmpty(epigrams) ? LIST_LAYOUT.flex : layout} data-testid='feed-layout'>
           {isLoading && <FeedEpigramSkeletonList count={PAGE_LIMIT} />}
 
           {/* 로딩 종료 후 empty 상태 조건부 렌더링 */}

--- a/src/components/feed/EpigramList.tsx
+++ b/src/components/feed/EpigramList.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { motion } from 'motion/react';
+import Link from 'next/link';
+
+import TextCard from '../ui/textcard';
+import RoundedButton from '../ui/buttons/roundedButton';
+import Image from 'next/image';
+import PlusIcon from '@/assets/icons/plus.svg';
+import { isEmpty } from 'es-toolkit/compat';
+import { useGetEpigrams } from '@/apis/epigram/queries';
+import EmptyEpigram from '@/assets/images/empty_epigram.svg';
+import { FeedEpigramButtonSkeleton, FeedEpigramSkeletonList } from '../ui/skeletons/FeedCardSkeleton';
+import { useState } from 'react';
+import GridIcon from '@/assets/icons/darhboard.svg';
+import FlexIcon from '@/assets/icons/sort.svg';
+
+const PAGE_LIMIT = 6;
+
+const MotionLink = motion.create(Link);
+
+const epigramListAnimation = {
+  exit: { opacity: 0, y: -10 },
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.2 },
+  whileHover: { y: -8, transition: { duration: 0.2 } },
+};
+
+const LIST_LAYOUT = {
+  grid: 'grid grid-cols-2 gap-x-4 gap-y-8 md:gap-x-6 md:gap-y-14 lg:gap-x-10 lg:gap-y-16',
+  flex: 'flex flex-col gap-8 md:gap-12 lg:gap-16',
+};
+
+export default function EpigramList() {
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useGetEpigrams({ limit: PAGE_LIMIT });
+  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
+  const totalCount = data?.pages.flatMap((page) => page.totalCount)[0] ?? 0;
+
+  const [isGridDisplay, setIsGridDisplay] = useState(true);
+  const layout = isGridDisplay ? LIST_LAYOUT.grid : LIST_LAYOUT.flex;
+
+  const handleClick = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  return (
+    <section className='flex flex-col gap-4 md:gap-8'>
+      <div className='flex w-full items-center justify-between'>
+        <h2 className='text-black-600 text-lg font-semibold md:text-2xl'>피드</h2>
+        <Image
+          src={isGridDisplay ? FlexIcon : GridIcon}
+          alt={isGridDisplay ? 'y축 정렬 아이콘' : '표 정렬 아이콘'}
+          width={36}
+          height={36}
+          className='size-6 cursor-pointer md:size-9'
+          onClick={() => setIsGridDisplay(!isGridDisplay)}
+        />
+      </div>
+      <>
+        <div className={!isLoading && isEmpty(epigrams) ? LIST_LAYOUT.flex : layout}>
+          {isLoading && <FeedEpigramSkeletonList count={PAGE_LIMIT} />}
+
+          {/* 로딩 종료 후 empty 상태 조건부 렌더링 */}
+          {!isLoading && isEmpty(epigrams) ? (
+            <Empty />
+          ) : (
+            epigrams.map((epigram) => (
+              <MotionLink
+                key={epigram.id}
+                variants={epigramListAnimation}
+                className='text-md cursor-pointer md:text-lg lg:text-xl xl:text-2xl'
+                href={`/epigrams/${epigram.id}`}
+                initial='initial'
+                animate='animate'
+                whileHover='whileHover'
+                exit='exit'
+                transition={epigramListAnimation.transition}
+              >
+                <TextCard author={epigram.author} cardContent={epigram.content} tags={epigram.tags} />
+              </MotionLink>
+            ))
+          )}
+
+          {isFetchingNextPage && <FeedEpigramSkeletonList count={PAGE_LIMIT} />}
+        </div>
+        {isLoading && <FeedEpigramButtonSkeleton />}
+        {hasNextPage && totalCount > epigrams.length && (
+          <div className='mt-8 flex w-full justify-center'>
+            <RoundedButton onClick={handleClick} variant='outline' className='gap-2'>
+              <Image src={PlusIcon} alt='에피그램 더보기' />
+              에피그램 더보기
+            </RoundedButton>
+          </div>
+        )}
+      </>
+    </section>
+  );
+}
+
+function Empty() {
+  return (
+    <motion.div exit={{ opacity: 0, y: -10 }} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }} className='flex flex-col items-center gap-4'>
+      <Image src={EmptyEpigram} alt='빈 피드 리스트' width={96} height={96} />
+      <p className='text-md from-black-700 via-black-400 to-black-200 flex flex-col items-center gap-2 bg-gradient-to-r bg-clip-text text-transparent md:text-xl'>
+        <span className='text-line'>아직 피드가 없어요!</span>
+        <span>에피그램을 만들고 다른 사람들에게 공유할 수 있어요.</span>
+      </p>
+    </motion.div>
+  );
+}

--- a/src/components/ui/skeletons/FeedCardSkeleton.tsx
+++ b/src/components/ui/skeletons/FeedCardSkeleton.tsx
@@ -1,0 +1,41 @@
+export function FeedEpigramSkeleton() {
+  return (
+    <div className='space-y-2'>
+      <div className='rounded-xl border border-gray-100 bg-white p-6 shadow-sm'>
+        <div className='mb-4 space-y-2'>
+          <div className='h-4 w-full animate-pulse rounded bg-gray-200'></div>
+
+          <div className='h-4 w-4/5 animate-pulse rounded bg-gray-200'></div>
+          <div className='h-4 w-11/12 animate-pulse rounded bg-gray-200'></div>
+        </div>
+
+        <div className='mt-4 flex justify-end'>
+          <div className='h-4 w-1/3 animate-pulse rounded bg-gray-200'></div>
+        </div>
+      </div>
+
+      <div className='mt-2 flex justify-end space-x-2'>
+        <div className='h-4 w-24 animate-pulse rounded bg-gray-200'></div>
+        <div className='h-4 w-28 animate-pulse rounded bg-gray-200'></div>
+      </div>
+    </div>
+  );
+}
+
+export function FeedEpigramButtonSkeleton() {
+  return (
+    <div className='flex w-full justify-center space-x-2'>
+      <div className='h-10 w-32 animate-pulse rounded-full bg-gray-200'></div>
+    </div>
+  );
+}
+
+export function FeedEpigramSkeletonList({ count }: { count: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <FeedEpigramSkeleton key={i} />
+      ))}
+    </>
+  );
+}

--- a/src/utils/network/axiosServerHelper.ts
+++ b/src/utils/network/axiosServerHelper.ts
@@ -49,7 +49,7 @@ axiosServerHelper.interceptors.response.use(
       cookieStore.set('accessToken', accessToken, {
         httpOnly: true,
         sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
+        secure: process.env.DOMAIN === process.env.NEXT_PUBLIC_PRODUCTION_DOMAIN,
         path: '/',
         expires: accessTokenExp || undefined,
       });


### PR DESCRIPTION
## ❓이슈
- close #166 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

Feed페이지 구현에 관한 PR입니다.

작업한 내용은 다음과 같습니다.

1. 피드 에피그램 리스트 구현
2. 레이아웃 토글 기능 구현
3. Webkit(사파리) 쿠키 미전송 이슈 해결 (환경 변수를 추가로 사용해야 해서 yml파일도 수정했습니다.)

### E2E 관련

쿠키가 Secure로 설정되어있을 때 크로미움이나 파이어폭스 기반 브라우저는 localhost일 때 해당 옵션을 무시해줍니다.
하지만, webkit 기반 브라우저는 위 두 엔진과 달리 localhost일 때 secure가 설정되어있으면 http이므로, 쿠키가 전송되지 않습니다.

next 앱을 build후 start하는 것은 production 환경이기 때문에 process.env.NODE_ENV의 값이 production으로 설정됩니다.

때문에 build 후 start했을 때 localhost환경이면, secure옵션이 켜지지 않도록 수정하였습니다.
(환경변수로 도메인 판단하여 secure 부여)

테스트 결과 에피그램 생성, 수정 페이지에서 발생했었던 webkit 이슈 해결된 것 로컬에서 확인 완료했습니다.

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
