### PR TITLE
EP-109 Tag 컴포넌트 파일명과 통일 

### DIFF
--- a/src/components/addEditForm/Tags.tsx
+++ b/src/components/addEditForm/Tags.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 import { TagInputProps } from '@/components/addEditForm/types';
 import Button from '@/components/ui/buttons/index';
 
-export default function TagInput({ value = [], onChange, label = '태그', required, error }: TagInputProps) {
+export default function Tags({ value = [], onChange, label = '태그', required, error }: TagInputProps) {
   const [newTag, setNewTag] = useState('');
   const [showAll, setShowAll] = useState(false); // 태그 모두 보기 토글 상태
   const [localError, setLocalError] = useState<string | null>(null);


### PR DESCRIPTION
## ❓이슈
- close #168 

## :writing_hand: Description

1. 태그 컴포넌트 이름이 Tagsinput -> Tags로 파일명과 동일하게 수정했습니다.
2. 기존의 Author 컴포넌트 내부의 onchange가 필요없어서 지우려고 했는데 이미 지워주셨더라구요 제가 확인을 못했네요 

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
