### PR TITLE
EP-125 검색페이지-검색리스트, 상세 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "dayjs": "^1.11.13",
         "es-toolkit": "^1.32.0",
         "lenis": "^1.2.3",
-        "lodash.debounce": "^4.0.8",
         "motion": "^12.4.10",
         "next": "15.2.1",
         "react": "^19.0.0",
@@ -12703,7 +12702,8 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dayjs": "^1.11.13",
         "es-toolkit": "^1.32.0",
         "lenis": "^1.2.3",
+        "lodash.debounce": "^4.0.8",
         "motion": "^12.4.10",
         "next": "15.2.1",
         "react": "^19.0.0",
@@ -12702,9 +12703,7 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "dayjs": "^1.11.13",
     "es-toolkit": "^1.32.0",
     "lenis": "^1.2.3",
-    "lodash.debounce": "^4.0.8",
     "motion": "^12.4.10",
     "next": "15.2.1",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dayjs": "^1.11.13",
     "es-toolkit": "^1.32.0",
     "lenis": "^1.2.3",
+    "lodash.debounce": "^4.0.8",
     "motion": "^12.4.10",
     "next": "15.2.1",
     "react": "^19.0.0",

--- a/src/app/(after-login)/(background-white)/search/page.tsx
+++ b/src/app/(after-login)/(background-white)/search/page.tsx
@@ -1,11 +1,12 @@
 "use client";
-import React from 'react';
-import { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
 import MainHeader from "@/components/ui/header/MainHeader";
-import SearchForm from '@/components/ui/searchForm';
-import SearchSave from '@/components/ui/searchSave';
-import { getEpigrams } from '@/apis/epigram';
-import SearchList from '@/components/ui/searchList';
+import SearchForm from "@/components/ui/searchForm";
+import SearchSave from "@/components/ui/searchSave";
+import { getEpigrams } from "@/apis/epigram";
+import SearchList from "@/components/ui/searchList";
 
 interface Epigram {
   id: number;
@@ -20,6 +21,9 @@ interface Epigram {
 }
 
 export default function SearchPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [results, setResults] = useState<Epigram[]>([]);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -27,7 +31,29 @@ export default function SearchPage() {
   const [hasMore, setHasMore] = useState<boolean>(false);
   const observerRef = useRef<HTMLDivElement | null>(null);
 
-  // 최근 검색어 불러오기
+  //결과 더 불러오기
+  const fetchMore = useCallback(
+    async (query: string, currentCursor: number, isNewSearch = false) => {
+      try {
+        const response = await getEpigrams({
+          keyword: query,
+          limit: 10,
+          cursor: currentCursor,
+        });
+
+        if (response?.list) {
+          setResults(prev => (isNewSearch ? response.list : [...prev, ...response.list]));
+          setCursor(response.nextCursor ?? 0);
+          setHasMore(response.list.length > 0);
+        }
+      } catch (error) {
+        console.error("무한스크롤 실패:", error);
+      }
+    },
+    []
+  );
+
+  //최근 검색어 불러오기
   useEffect(() => {
     const stored = localStorage.getItem("recentSearches");
     if (stored) {
@@ -35,12 +61,27 @@ export default function SearchPage() {
     }
   }, []);
 
-  // 검색 실행
+  //새로고침 시 URL에서 검색어 받아서 자동 검색
+  useEffect(() => {
+    const q = searchParams.get("q");
+    if (q) {
+      setSearchQuery(q);
+      fetchMore(q, 0, true);
+    }
+  }, [searchParams, fetchMore]);
+
+  //검색 실행 함수
   const handleSearch = async (query: string) => {
     setSearchQuery(query);
     setCursor(0);
     setResults([]);
 
+    // 검색어 URL에 반영
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("q", query);
+    router.push(`?${params.toString()}`);
+
+    // 최근 검색어 업데이트
     const updated = [query, ...recentSearches.filter(item => item !== query)].slice(0, 10);
     setRecentSearches(updated);
     localStorage.setItem("recentSearches", JSON.stringify(updated));
@@ -48,26 +89,8 @@ export default function SearchPage() {
     await fetchMore(query, 0, true);
   };
 
-  // 더 불러오기 함수
-  const fetchMore = useCallback(async (query: string, currentCursor: number, isNewSearch = false) => {
-    try {
-      const response = await getEpigrams({
-        keyword: query,
-        limit: 10,
-        cursor: currentCursor,
-      });
 
-      if (response?.list) {
-        setResults(prev => isNewSearch ? response.list : [...prev, ...response.list]);
-        setCursor(response.nextCursor ?? 0);
-        setHasMore(response.list.length > 0);
-      }
-    } catch (error) {
-      console.error("무한스크롤 실패:", error);
-    }
-  }, []);
-
-  // IntersectionObserver
+  //IntersectionObserver로 무한 스크롤
   useEffect(() => {
     if (!hasMore || !searchQuery) return;
 
@@ -98,7 +121,6 @@ export default function SearchPage() {
       <MainHeader />
       <SearchForm onSearch={handleSearch} />
       <SearchSave searches={recentSearches} onClear={handleClear} />
-
       <SearchList
         results={results}
         keyword={searchQuery}

--- a/src/app/(after-login)/(background-white)/search/page.tsx
+++ b/src/app/(after-login)/(background-white)/search/page.tsx
@@ -75,7 +75,7 @@ export default function SearchPage() {
     const q = params.get("q");
     if (q) {
       setSearchQuery(q);
-      fetchMore(q, 0, true);
+      fetchMore(q, 0, true); 
     }
   }, [isClient, fetchMore]);
 

--- a/src/app/(after-login)/(background-white)/search/page.tsx
+++ b/src/app/(after-login)/(background-white)/search/page.tsx
@@ -1,15 +1,34 @@
 "use client";
-
-import { useEffect, useState } from 'react';
+import React from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import MainHeader from "@/components/ui/header/MainHeader";
 import SearchForm from '@/components/ui/searchForm';
 import SearchSave from '@/components/ui/searchSave';
+import { getEpigrams } from '@/apis/epigram';
+import { Iropke } from '@/fonts';
+import SearchList from '@/components/ui/searchList';
+
+interface Epigram {
+  id: number;
+  content: string;
+  author: string;
+  referenceTitle: string | null;
+  referenceUrl: string | null;
+  writerId: number;
+  likeCount: number;
+  tags: { id: number; name: string }[];
+  isLiked?: boolean;
+}
 
 export default function SearchPage() {
-
-  const [results, setResults] = useState<string[]>([]);
+  const [results, setResults] = useState<Epigram[]>([]);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [cursor, setCursor] = useState<number>(0);
+  const [hasMore, setHasMore] = useState<boolean>(false);
+  const observerRef = useRef<HTMLDivElement | null>(null);
 
+  // 최근 검색어 불러오기
   useEffect(() => {
     const stored = localStorage.getItem("recentSearches");
     if (stored) {
@@ -17,14 +36,58 @@ export default function SearchPage() {
     }
   }, []);
 
-  const handleSearch = (query: string) => {
-    console.log("검색어:", query);
-    setResults([]); // 현재는 결과 없음 처리
+  // 검색 실행
+  const handleSearch = async (query: string) => {
+    setSearchQuery(query);
+    setCursor(0);
+    setResults([]);
 
     const updated = [query, ...recentSearches.filter(item => item !== query)].slice(0, 10);
     setRecentSearches(updated);
     localStorage.setItem("recentSearches", JSON.stringify(updated));
+
+    await fetchMore(query, 0, true);
   };
+
+  // 더 불러오기 함수
+  const fetchMore = useCallback(async (query: string, currentCursor: number, isNewSearch = false) => {
+    try {
+      const response = await getEpigrams({
+        keyword: query,
+        limit: 10,
+        cursor: currentCursor,
+      });
+
+      if (response?.list) {
+        setResults(prev => isNewSearch ? response.list : [...prev, ...response.list]);
+        setCursor(response.nextCursor ?? 0);
+        setHasMore(response.list.length > 0);
+      }
+    } catch (error) {
+      console.error("무한스크롤 실패:", error);
+    }
+  }, []);
+
+  // IntersectionObserver
+  useEffect(() => {
+    if (!hasMore || !searchQuery) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting) {
+          fetchMore(searchQuery, cursor);
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    const target = observerRef.current;
+    if (target) observer.observe(target);
+
+    return () => {
+      if (target) observer.unobserve(target);
+    };
+  }, [cursor, fetchMore, searchQuery, hasMore]);
 
   const handleClear = () => {
     setRecentSearches([]);
@@ -33,25 +96,16 @@ export default function SearchPage() {
 
   return (
     <>
-
       <MainHeader />
       <SearchForm onSearch={handleSearch} />
       <SearchSave searches={recentSearches} onClear={handleClear} />
 
-      <div className="max-w-[680px] mx-auto w-full px-5 mt-4">
-        {results.length > 0 ? (
-          <ul className="divide-y divide-gray-300">
-            {results.map((item, index) => (
-              <li key={index} className="py-2">
-                {item}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-center text-gray-500 mt-4">검색 결과가 없습니다.</p>
-        )}
-      </div>
-
+      <SearchList
+        results={results}
+        keyword={searchQuery}
+        hasMore={hasMore}
+        observerRef={observerRef}
+      />
     </>
   );
 }

--- a/src/app/(after-login)/(background-white)/search/page.tsx
+++ b/src/app/(after-login)/(background-white)/search/page.tsx
@@ -5,7 +5,6 @@ import MainHeader from "@/components/ui/header/MainHeader";
 import SearchForm from '@/components/ui/searchForm';
 import SearchSave from '@/components/ui/searchSave';
 import { getEpigrams } from '@/apis/epigram';
-import { Iropke } from '@/fonts';
 import SearchList from '@/components/ui/searchList';
 
 interface Epigram {

--- a/src/app/(after-login)/(background-white)/search/page.tsx
+++ b/src/app/(after-login)/(background-white)/search/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useRef, useState, useCallback } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 import MainHeader from "@/components/ui/header/MainHeader";
 import SearchForm from "@/components/ui/searchForm";
@@ -22,16 +22,17 @@ interface Epigram {
 
 export default function SearchPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [results, setResults] = useState<Epigram[]>([]);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [cursor, setCursor] = useState<number>(0);
   const [hasMore, setHasMore] = useState<boolean>(false);
+  const [isClient, setIsClient] = useState<boolean>(false); // 클라이언트 여부 체크
+
   const observerRef = useRef<HTMLDivElement | null>(null);
 
-  //결과 더 불러오기
+  // 결과 더 불러오기
   const fetchMore = useCallback(
     async (query: string, currentCursor: number, isNewSearch = false) => {
       try {
@@ -53,7 +54,12 @@ export default function SearchPage() {
     []
   );
 
-  //최근 검색어 불러오기
+  // 클라이언트 여부 체크
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  // 최근 검색어 불러오기
   useEffect(() => {
     const stored = localStorage.getItem("recentSearches");
     if (stored) {
@@ -61,23 +67,26 @@ export default function SearchPage() {
     }
   }, []);
 
-  //새로고침 시 URL에서 검색어 받아서 자동 검색
+  // 새로고침 시 URL에서 검색어 받아서 자동 검색
   useEffect(() => {
-    const q = searchParams.get("q");
+    if (!isClient) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get("q");
     if (q) {
       setSearchQuery(q);
       fetchMore(q, 0, true);
     }
-  }, [searchParams, fetchMore]);
+  }, [isClient, fetchMore]);
 
-  //검색 실행 함수
+  // 검색 실행 함수
   const handleSearch = async (query: string) => {
     setSearchQuery(query);
     setCursor(0);
     setResults([]);
 
     // 검색어 URL에 반영
-    const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(window.location.search);
     params.set("q", query);
     router.push(`?${params.toString()}`);
 
@@ -89,8 +98,7 @@ export default function SearchPage() {
     await fetchMore(query, 0, true);
   };
 
-
-  //IntersectionObserver로 무한 스크롤
+  // IntersectionObserver로 무한 스크롤
   useEffect(() => {
     if (!hasMore || !searchQuery) return;
 

--- a/src/components/ui/searchForm/index.tsx
+++ b/src/components/ui/searchForm/index.tsx
@@ -1,14 +1,21 @@
 "use client";
-import Image from 'next/image';
+import Image from "next/image";
+import { useState, useEffect } from "react";
 import SearchImage from "@/assets/icons/searchIcon.svg";
-import { useState } from 'react';
+import { useSearchParams } from "next/navigation";
 
 interface SearchFormProps {
   onSearch: (query: string) => void;
 }
 
 export default function SearchForm({ onSearch }: SearchFormProps) {
-  const [search, setSearch] = useState("");
+  const searchParams = useSearchParams();
+  const initialSearch = searchParams.get("q") || "";
+  const [search, setSearch] = useState(initialSearch);
+
+  useEffect(() => {
+    setSearch(initialSearch);
+  }, [initialSearch]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/ui/searchForm/index.tsx
+++ b/src/components/ui/searchForm/index.tsx
@@ -3,20 +3,22 @@
 import Image from "next/image";
 import { useState, useEffect } from "react";
 import SearchImage from "@/assets/icons/searchIcon.svg";
-import { useSearchParams } from "next/navigation";
 
 interface SearchFormProps {
   onSearch: (query: string) => void;
 }
 
 export default function SearchForm({ onSearch }: SearchFormProps) {
-  const searchParams = useSearchParams();
-  const initialSearch = searchParams.get("q") || "";
-  const [search, setSearch] = useState(initialSearch);
+  const [search, setSearch] = useState("");
 
+  // 클라이언트에서 URL 쿼리 직접 파싱
   useEffect(() => {
-    setSearch(initialSearch);
-  }, [initialSearch]);
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      const initialSearch = params.get("q") || "";
+      setSearch(initialSearch);
+    }
+  }, []);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/ui/searchForm/index.tsx
+++ b/src/components/ui/searchForm/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import Image from "next/image";
 import { useState, useEffect } from "react";
 import SearchImage from "@/assets/icons/searchIcon.svg";

--- a/src/components/ui/searchList/index.tsx
+++ b/src/components/ui/searchList/index.tsx
@@ -1,0 +1,85 @@
+'use client'; // 👈 꼭 필요함!
+
+import { useRouter } from 'next/navigation';
+
+import type { RefObject } from 'react';
+import type { JSX } from 'react';
+import { Iropke } from "@/fonts";
+
+interface Epigram {
+  id: number;
+  content: string;
+  author: string;
+  referenceTitle: string | null;
+  referenceUrl: string | null;
+  writerId: number;
+  likeCount: number;
+  tags: { id: number; name: string }[];
+  isLiked?: boolean;
+}
+
+interface SearchListProps {
+  results: Epigram[];
+  keyword: string;
+  hasMore: boolean;
+  observerRef: RefObject<HTMLDivElement | null>;
+}
+
+function highlightKeyword(text: string, keyword: string): JSX.Element {
+  if (!keyword) return <>{text}</>;
+  const parts = text.split(new RegExp(`(${keyword})`, 'gi'));
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.toLowerCase() === keyword.toLowerCase() ? (
+          <span key={index} className="text-illust-blue">{part}</span>
+        ) : (
+          <span key={index}>{part}</span>
+        )
+      )}
+    </>
+  );
+}
+
+export default function SearchList({ results, keyword, hasMore, observerRef }: SearchListProps) {
+  const router = useRouter();
+
+  const goToDetail = (id: number) => {
+    router.push(`/epigrams/${id}`);
+  };
+
+  return (
+    <div className="max-w-[680px] mx-auto w-full px-5 mt-4">
+      {results.length > 0 ? (
+        <ul className="divide-y divide-gray-100">
+          {results.map((item, index) => (
+            <li
+              key={`${item.id}-${index}`}
+              className="py-4 md:py-4 xl:py-6 cursor-pointer hover:bg-gray-50 transition"
+              onClick={() => goToDetail(item.id)}
+            >
+              <p className={`${Iropke.className} text-black-600 mb-1 sm:mb-1 md:mb-2 lg:mb-6 text-lg md:text-lg lg:text-xl leading-snug`}>
+                {highlightKeyword(item.content, keyword)}
+              </p>
+              <p className={`${Iropke.className} text-blue-400 mb-2 md:mb-2 lg:mb-4 text-lg md:text-lg lg:text-xl`}>
+                - {item.author} -
+              </p>
+
+              <div className="flex flex-wrap gap-3 justify-end">
+                {item.tags.map(tag => (
+                  <span key={tag.id} className="text-blue-400 text-lg md:text-lg lg:text-xl">
+                    #{highlightKeyword(tag.name, keyword)}
+                  </span>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-center text-gray-500 mt-10 md:mt-10 lg:mt-20">검색 결과가 없습니다.</p>
+      )}
+
+      {hasMore && <div ref={observerRef} className="h-10" />}
+    </div>
+  );
+}

--- a/src/components/ui/searchList/index.tsx
+++ b/src/components/ui/searchList/index.tsx
@@ -1,4 +1,4 @@
-'use client'; // 👈 꼭 필요함!
+'use client';
 
 import { useRouter } from 'next/navigation';
 

--- a/src/components/ui/searchSave/index.tsx
+++ b/src/components/ui/searchSave/index.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import Chip from "../Chip";
 
 interface Props {
@@ -22,7 +21,7 @@ export default function SearchSave({ searches, onClear }: Props) {
       </div>
       {
         searches.length > 0 && (
-          <div className="flex flex-wrap gap-2 sm:gap-2 md:gap-4 lg:gap-4">
+          <div className="flex flex-wrap gap-2 sm:gap-2 md:gap-4 lg:gap-4 mb-6 sm:mb-6 md:mb-7 lg:mb-8">
             {searches.map((keyword, index) => (
               <Chip key={index} label={keyword} />
             ))}


### PR DESCRIPTION
## ❓이슈
- close #196 

## :writing_hand: Description
검색페이지 검색시 검색리스트를 불러오고 상세페이지로 이동할 수 있습니다.
무한스크롤 기능이 구현되어 있고 검색 키워드는 하이라이팅 처리되어 있습니다.

## :white_check_mark: Checklist

### PR
- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
