### PR TITLE
EP-135 마이페이지 프로필 사진 최적화 리팩토링

### DIFF
--- a/src/components/mypage/UserProfileLayout.tsx
+++ b/src/components/mypage/UserProfileLayout.tsx
@@ -28,7 +28,13 @@ export default function UserProfileLayout() {
 
   return (
     <div className='absolute top-0 left-1/2 flex -translate-x-1/2 -translate-y-[40px] flex-col items-center justify-center gap-4 lg:-translate-y-[60px] lg:gap-6'>
-      <Avatar src={user.image} alt='유저이미지' className='size-20 cursor-pointer border-2 border-blue-300 lg:size-[120px]' onClick={handleAvatarClick} priority></Avatar>
+      <Avatar
+        src={user?.image ?? process.env.NEXT_PUBLIC_DEFAULT_IMAGE_URL}
+        alt='유저이미지'
+        className='size-20 cursor-pointer border-2 border-blue-300 lg:size-[120px]'
+        onClick={handleAvatarClick}
+        priority
+      ></Avatar>
       <input type='file' className='hidden' onChange={handleChangeImage} accept='image/*' ref={fileInputRef} />
       <p className='text-black-950 text-lg font-medium lg:text-2xl'>{user.nickname}</p>
       <LogoutButton className='h-9 w-[77px] px-3.5 py-1.5 text-[14px] font-normal whitespace-nowrap lg:h-12 lg:w-[100px] lg:px-4 lg:py-2 lg:text-xl lg:font-medium'></LogoutButton>

--- a/src/context/MypageProvider.tsx
+++ b/src/context/MypageProvider.tsx
@@ -4,18 +4,20 @@ import { useGetUser } from '@/apis/user/queries';
 import dayjs, { Dayjs } from 'dayjs';
 import { useGetMonthlyEmotionLogs } from '@/apis/emotion-log/queries';
 
+const defaultUser = {
+  image: process.env.NEXT_PUBLIC_DEFAULT_IMAGE_URL ?? '',
+  createdAt: '',
+  updatedAt: '',
+  teamId: '',
+  nickname: '사용자',
+  id: 0,
+};
+
 export const MypageContext = createContext<CreateContext>({
   currentDate: dayjs(),
   setCurrentDate: () => {},
   userEmotion: [],
-  user: {
-    image: '',
-    createdAt: '',
-    updatedAt: '',
-    teamId: '',
-    nickname: '',
-    id: 0,
-  },
+  user: defaultUser,
 });
 
 export default function MypageProvider({ children }: PropsWithChildren) {
@@ -32,7 +34,16 @@ export default function MypageProvider({ children }: PropsWithChildren) {
     enabled: !!user && !!currentDate,
   });
 
-  if (!user || !userEmotion) return <div>로딩 중...</div>;
-
-  return <MypageContext.Provider value={{ currentDate, setCurrentDate, userEmotion, user }}>{children}</MypageContext.Provider>;
+  return (
+    <MypageContext.Provider
+      value={{
+        currentDate,
+        setCurrentDate,
+        userEmotion: userEmotion ?? [],
+        user: user ?? defaultUser,
+      }}
+    >
+      {children}
+    </MypageContext.Provider>
+  );
 }


### PR DESCRIPTION
## ❓이슈
- close #219 

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
마이페이지 프로필 사진 최적화 리팩토링에 대한 PR입니다.
기존에는 데이터를 가지고 오는 시간동안 랜더링되는 부분이 없어서 기다리는 시간이 길어져 LCP가 길어졌습니다.
초기 데이터가 없는 동안에는 기본이미지를 가지고 온 다음, 데이터가 불러오면 해당 user이미지를 적용시키는 방향으로 수정하였습니다.

### 개선전
![스크린샷 2025-04-20 144855](https://github.com/user-attachments/assets/befff734-c002-457d-8ac4-ac0cac3fe46d)

### 개선후
![스크린샷 2025-04-20 162015](https://github.com/user-attachments/assets/5f2745ff-16dc-41b2-a1e5-f2b5d8114cc2)


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
